### PR TITLE
Small changes to enable Multi Host networking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
       <org.junit.platform.version>1.3.0</org.junit.platform.version>
       <org.junit.jupiter.version>5.4.0</org.junit.jupiter.version>
       <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
-      <org.java-docker.version>3.1.2</org.java-docker.version>
+      <org.java-docker.version>3.2.1</org.java-docker.version>
       <org.slf4j.version>1.7.5</org.slf4j.version>
       <org.codehouse.mojo.version>1.6.0</org.codehouse.mojo.version>
       <org.args4j.version>2.33</org.args4j.version>
@@ -217,17 +217,17 @@
       <dependency>
          <groupId>javax.xml.bind</groupId>
          <artifactId>jaxb-api</artifactId>
-         <version>2.2.11</version>
+         <version>2.3.1</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-core</artifactId>
-         <version>2.2.11</version>
+         <version>2.3.0.1</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-impl</artifactId>
-         <version>2.2.11</version>
+         <version>2.3.3</version>
       </dependency>
       <dependency>
          <groupId>javax.activation</groupId>

--- a/src/main/java/io/patriot_framework/network_simulator/docker/container/Container.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/container/Container.java
@@ -65,4 +65,9 @@ public interface Container {
      */
     void destroyContainer();
 
+    /**
+     * Start container.
+     */
+    void startContainer();
+
 }

--- a/src/main/java/io/patriot_framework/network_simulator/docker/container/DockerContainer.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/container/DockerContainer.java
@@ -146,6 +146,11 @@ public class DockerContainer implements Container {
         dockerManager.destroyContainer(this);
     }
 
+    @Override
+    public void startContainer() {
+        dockerManager.startContainer(this);
+    }
+
     /**
      * Method gathers ip of container's gateway.
      *

--- a/src/main/java/io/patriot_framework/network_simulator/docker/manager/Manager.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/manager/Manager.java
@@ -20,6 +20,7 @@ import io.patriot_framework.network.simulator.api.model.network.Network;
 import io.patriot_framework.network_simulator.docker.container.Container;
 
 import java.io.File;
+import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
@@ -79,15 +80,15 @@ public interface Manager {
     /**
      * Method stops container.
      *
-     * @param container
+     * @param container the container
      */
     void killContainer(Container container);
 
     /**
      * Disconnects container from network.
      *
-     * @param container
-     * @param network
+     * @param container the container
+     * @param network   the network
      */
     void disconnectContainer(Container container, Network network);
 
@@ -135,4 +136,8 @@ public interface Manager {
      */
     void deleteImage(String tag);
 
+    /**
+     * @return URI of the host running the manager
+     */
+    URI getHost();
 }


### PR DESCRIPTION
* Add `startContainer()` method to `Container`.
* Implement `equals()` and `hashCode()` for `DockerManager.`
  * Add `getHost()` method to `Manager` to be able to differenciate between Managers running on different hosts.
* Bump `java-docker` version to 3.2.1
* Bump `jaxb` to 2.3.x

I have split MultiHost networking PRs into two, one (this) with all the changes to existing code and the second one for the actual new functionality.