### PR TITLE
[WIP] Moving hardcoded docker simulation from patriot-api

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="docker-network-simulator" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
       <org.args4j.version>2.33</org.args4j.version>
       <org.etcd4j.version>2.18.0</org.etcd4j.version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <com.github.jgonian.version>1.32</com.github.jgonian.version>
    </properties>
 
    <build>
@@ -229,6 +230,11 @@
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-impl</artifactId>
          <version>2.3.3</version>
+      </dependency>
+      <dependency>
+         <groupId>com.github.jgonian</groupId>
+         <artifactId>commons-ip-math</artifactId>
+         <version>${com.github.jgonian.version}</version>
       </dependency>
 
       <dependency>

--- a/src/main/java/io/patriot_framework/network_simulator/docker/CalculatedRouteList.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/CalculatedRouteList.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker;
+
+import java.util.ArrayList;
+
+/**
+ * The type Calculated route list with extended add method to avoid inserting Route to non-existing index.
+ *
+ * @param <t> the type parameter
+ */
+public class CalculatedRouteList<t> extends ArrayList<t> {
+    @Override
+    public void add(int i, t o) {
+        int size = super.size();
+        if (size > i && super.get(i) == null) {
+            super.set(i, o);
+        } else {
+            if (super.size() <= i) {
+                for (int y = super.size(); y < i; y++) {
+                    super.add(null);
+                }
+            }
+            super.add(i, o);
+        }
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/api/iproute/RouteRestController.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/api/iproute/RouteRestController.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.api.iproute;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.patriot_framework.network.simulator.api.api.RestController;
+import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
+import io.patriot_framework.network_simulator.docker.model.routes.Route;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * RestController for ip tables api.
+ * Implementing RestController. Is used for work with http ip-route rest api running in container.
+ *
+ */
+public class RouteRestController extends RestController {
+    /**
+     * Add route string.
+     *
+     * @param route the route
+     * @param ip ip of route
+     * @param port port
+     * @return the string
+     */
+    public String addRoute(Route route, String ip, Integer port) {
+        String path = "/iproutes/mod?" + route.toAPIFormat();
+        return executeHttpRequest(path, "PUT", ip, port);
+    }
+
+    /**
+     * Delete route string.
+     *
+     * @param route the route
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     */
+    public String deleteRoute(Route route, String ip, Integer port) {
+        String path = "/iproutes/mod?" + route.toAPIFormat();
+        return executeHttpRequest(path, "DELETE", ip, port);
+    }
+
+    /**
+     * Gets routers.
+     *
+     * @param ip the ip
+     * @param port the port
+     * @return the routers
+     */
+    public List<Route> getRoutes(String ip, Integer port) {
+        String path = "/iproutes";
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String input = executeHttpRequest(path, "GET", ip, port);
+            return objectMapper.readValue(input, new TypeReference<List<Route>>(){});
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Add default gw string.
+     *
+     * @param defaultGW the default gw
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     */
+    public String addDefaultGW(Route defaultGW, String ip, Integer port) {
+        String path = "/iproutes/default?interface=" + defaultGW.getrNetworkInterface().getIp();
+        return executeHttpRequest(path, "PUT", ip, port);
+    }
+
+    /**
+     * Del default gw string.
+     *
+     * @param defaultGW the default gw
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     */
+    public String delDefaultGW(Route defaultGW, String ip, Integer port) {
+        String path = "/iproutes/default?interface=" + defaultGW.getrNetworkInterface().getIp();
+        return executeHttpRequest(path, "DELETE", ip, port);
+    }
+
+    /**
+     * Remove default gateway
+     * @param ip ip of container
+     * @param port control port of container
+     * @return result of executed action
+     */
+    public String delDefaultGw(String ip, Integer port) {
+        String path = "/iproutes/default";
+        return executeHttpRequest(path, "DELETE", ip, port);
+    }
+
+
+
+    /**
+     * Gets interfaces.
+     *
+     * @param ip the ip
+     * @param port the port
+     * @return the interfaces
+     */
+    public List<NetworkInterface> getInterfaces(String ip, Integer port) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String input = executeHttpRequest("/interfaces", "GET", ip, port);
+            List<NetworkInterface> networkInterfaces =
+                    objectMapper.readValue(input, new TypeReference<List<NetworkInterface>>(){});
+            return networkInterfaces;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/IPTablesRestController.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/IPTablesRestController.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.api.iptables;
+
+import io.patriot_framework.network.simulator.api.api.RestController;
+import io.patriot_framework.network.simulator.api.api.iptables.chain.Chain;
+import io.patriot_framework.network.simulator.api.api.iptables.rules.FilterRule;
+
+/**
+ * The type Ip tables controller.
+ */
+public class IPTablesRestController extends RestController {
+
+    /**
+     * Add filter rule string.
+     *
+     * @param filterRule the filter rule
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     **/
+    public String addFilterRule(FilterRule filterRule, String ip, Integer port) {
+
+        return executeHttpRequest(filterRule.toAPIFormat(), "PUT", ip, port);
+    }
+
+    /**
+     * Delete filter rule string.
+     *
+     * @param filterRule the filter rule
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     **/
+    public String deleteFilterRule(FilterRule filterRule, String ip, Integer port) {
+        return executeHttpRequest(filterRule.toAPIFormat(), "DELETE", ip, port);
+    }
+
+
+    /**
+     * Add chain string.
+     *
+     * @param chain the chain
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     **/
+    public String addChain(Chain chain, String ip, Integer port) {
+        return executeHttpRequest(chain.toString(), "PUT", ip, port);
+    }
+
+    /**
+     * Delete chain string.
+     *
+     * @param chain the chain
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     **/
+    public String deleteChain(Chain chain, String ip, Integer port) {
+        return executeHttpRequest(chain.getPath(), "DELETE", ip, port);
+    }
+
+
+    /**
+     * Save ip tables string.
+     *
+     * @param ip the ip
+     * @param port the port
+     * @return the string
+     **/
+    public String saveIpTables(String ip, Integer port) {
+        return executeHttpRequest("/save/", "GET", ip, port);
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/IPTablesRestController.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/IPTablesRestController.java
@@ -17,8 +17,9 @@
 package io.patriot_framework.network_simulator.docker.api.iptables;
 
 import io.patriot_framework.network.simulator.api.api.RestController;
-import io.patriot_framework.network.simulator.api.api.iptables.chain.Chain;
-import io.patriot_framework.network.simulator.api.api.iptables.rules.FilterRule;
+import io.patriot_framework.network_simulator.docker.api.iptables.chain.Chain;
+import io.patriot_framework.network_simulator.docker.api.iptables.rules.FilterRule;
+
 
 /**
  * The type Ip tables controller.

--- a/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/chain/Chain.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/chain/Chain.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.api.iptables.chain;
+
+/**
+ * IpTables chain.
+ */
+public class Chain {
+    private String name;
+    private String table;
+
+    /**
+     * Instantiates a new Chain.
+     *
+     * @param name  the name
+     * @param table the table
+     */
+    public Chain(String name, String table) {
+        this.name = name;
+        this.table = table;
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets table.
+     *
+     * @return the table
+     */
+    public String getTable() {
+        return table;
+    }
+
+    /**
+     * Sets table.
+     *
+     * @param table the table
+     */
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    /**
+     * Gets path.
+     *
+     * @return the path
+     */
+    public String getPath() {
+        return "/chain/" + table + "/" + name + "/";
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/rules/FilterRule.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/api/iptables/rules/FilterRule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.api.iptables.rules;
+
+import java.util.LinkedHashMap;
+
+/**
+ * The type Filter rule.
+ */
+public class FilterRule {
+    private LinkedHashMap<String, String> attributes = new LinkedHashMap<>();
+
+    /**
+     * Instantiates a new Filter rule with default attributes.
+     */
+    public FilterRule() {
+
+        attributes.put("action", null);
+        attributes.put("chain", null);
+        attributes.put("proto", null);
+        attributes.put("iface-in", "any");
+        attributes.put("iface-out", "any");
+        attributes.put("source", null);
+        attributes.put("destination", null);
+    }
+
+    public String toAPIFormat() {
+        String rules= "/rules/";
+        for (String value : attributes.values()) {
+            rules += value + "/";
+        }
+        return rules;
+    }
+
+    /**
+     * Gets attributes.
+     *
+     * @return the attributes
+     */
+    public LinkedHashMap<String, String> getAttributes() {
+        return attributes;
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/CalcRouteBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/CalcRouteBuilder.java
@@ -17,7 +17,7 @@
 package io.patriot_framework.network_simulator.docker.builder;
 
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
 
@@ -159,7 +159,7 @@ public class CalcRouteBuilder {
      * @return index of target network in topology list of networks.
      */
     private Integer findNetworkByName(String name) {
-        List<TopologyNetwork> topologyNetworks = topologyBuilder.getTopology().getNetworks();
+        List<ContainerNetwork> topologyNetworks = topologyBuilder.getTopology().getNetworks();
         for (int i = 0; i < topologyNetworks.size(); i++) {
             if (topologyNetworks.get(i).getName().equals(name)) {
                 return i;

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/CalcRouteBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/CalcRouteBuilder.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.builder;
+
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
+
+import java.util.List;
+
+/**
+ * The type Calc route builder.
+ */
+public class CalcRouteBuilder {
+    /**
+     * The RouterImpl.
+     */
+    private Router router;
+    /**
+     * The source network.
+     */
+    private int sourceNetwork;
+    /**
+     * Cost of route (hops).
+     */
+    private int cost;
+    /**
+     * The destination network.
+     */
+    private int destNetwork;
+
+    /**
+     * The TopologyNetwork builder.
+     */
+    private NetworkBuilder networkBuilder;
+    /**
+     * The Topology builder.
+     */
+    private TopologyBuilder topologyBuilder;
+
+    public CalcRouteBuilder(int destNetwork) {
+        this.destNetwork = destNetwork;
+    }
+
+    /**
+     * Instantiates a new Calc route builder.
+     * This CalcRouteBuilder is used to describe all routes in
+     * network topology with just one calcRoutes build.
+     * Provides auto completing of routes (route ws -&gt; internet will be
+     * auto completed with route internet -&gt; ws) which saves a lot of time.
+     *
+     * @param topologyBuilder the topology builder
+     */
+    public CalcRouteBuilder(TopologyBuilder topologyBuilder) {
+        this.topologyBuilder = topologyBuilder;
+    }
+
+    /**
+     * Instantiates a new Calc route builder.
+     * This CalcRouteBuilder is used to describe CalculatedRoutes just for
+     * one network without auto complete etc...
+     *
+     * @param networkBuilder the network builder
+     */
+    public CalcRouteBuilder(NetworkBuilder networkBuilder) {
+        this.networkBuilder = networkBuilder;
+    }
+
+    /**
+     * Finds router based on it`s name and sets it as router attribute.
+     *
+     * @param routerName the router name
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder viaRouter(String routerName) {
+        this.router = topologyBuilder.getTopology().findRouterByName(routerName);
+        return this;
+    }
+
+    /**
+     * Adds router attribute.
+     *
+     * @param router Router
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder viaRouter(Router router) {
+        this.router = router;
+        return this;
+    }
+
+    /**
+     * Adds cost attribute.
+     *
+     * @param cost the cost
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder withCost(Integer cost) {
+        this.cost = cost;
+        return this;
+    }
+
+    /**
+     * Adds destination network attribute. Identified by name.
+     * This method has to be used with topology builder,
+     * not with network builder.
+     *
+     * @param targetNetworkName the target network name
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder withDestNetwork(String targetNetworkName) {
+        this.destNetwork = findNetworkByName(targetNetworkName);
+        return this;
+    }
+
+    /**
+     * With dest network calc route builder.
+     * Method has to be used with network builder.
+     *
+     * @param targetNetworkIndex the target network index
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder withDestNetwork(Integer targetNetworkIndex) {
+        this.destNetwork = targetNetworkIndex;
+        return this;
+    }
+
+    /**
+     * Adds source network attribute. Identified by name.
+     * This method has to be used with topology builder,
+     * not with network builder.
+     *
+     * @param sourceNetworkName the source network name
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder withSourceNetwork(String sourceNetworkName) {
+        this.sourceNetwork = findNetworkByName(sourceNetworkName);
+        return this;
+    }
+
+    /**
+     * Find network by name in topology networks.
+     *
+     * @param name target network name.
+     * @return index of target network in topology list of networks.
+     */
+    private Integer findNetworkByName(String name) {
+        List<TopologyNetwork> topologyNetworks = topologyBuilder.getTopology().getNetworks();
+        for (int i = 0; i < topologyNetworks.size(); i++) {
+            if (topologyNetworks.get(i).getName().equals(name)) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * With source network calc route builder.
+     *
+     * @param sourceNetwork the source network
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder withSourceNetwork(Integer sourceNetwork) {
+        this.sourceNetwork = sourceNetwork;
+        return this;
+    }
+
+    /**
+     * Create route with opposite direction and add both routes into
+     * their positions in calcRoutesLists in networks.
+     *
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder addRoute() {
+        CalcRoute sR = new CalcRoute(new NextHop(router, destNetwork), cost);
+        topologyBuilder.getTopology().getNetworks().get(sourceNetwork).getCalcRoutes().add(destNetwork, sR);
+
+        if (sourceNetwork != destNetwork) {
+            CalcRoute dR = new CalcRoute(new NextHop(router, sourceNetwork), cost);
+            topologyBuilder.getTopology().getNetworks().get(destNetwork).getCalcRoutes().add(sourceNetwork, dR);
+        }
+        return this;
+    }
+
+    /**
+     * Complete routes by route which point to themselves (N1 -&gt; N1) and
+     * returns topology builder updated by added routes.
+     *
+     * @return the topology builder
+     */
+    public TopologyBuilder buildRoutes() {
+
+        for (int i = 0; i < topologyBuilder.getTopology().getNetworks().size(); i++) {
+            CalcRoute cR = new CalcRoute(new NextHop(null, i), null);
+            topologyBuilder.getTopology().getNetworks().get(i).getCalcRoutes().add(i, cR);
+        }
+
+        return topologyBuilder;
+    }
+
+    /**
+     * Creates route.
+     * @return calcRoute
+     */
+    public CalcRoute createCalcRoute() {
+        CalcRoute sR = new CalcRoute(new NextHop(router, destNetwork), cost);
+        return sR;
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/NetworkBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/NetworkBuilder.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.builder;
+
+import io.patriot_framework.network_simulator.docker.CalculatedRouteList;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+
+/**
+ * TopologyNetwork Builder provides functions for building network and adding it into topology.
+ * TopologyNetwork Builder have to cooperate with CalcRouteBuilder and Topology builder.
+ */
+public class NetworkBuilder {
+
+    /**
+     * Creator of network (docker, VM, ...)
+     */
+    private Object creator;
+    private String ipAddress;
+    private String name;
+    private int mask = 0;
+    private Boolean internet = false;
+
+    /**
+     * CalculatedRouteList is list with routes to other networks, usually created with CalcRouteBuilder.
+     */
+    public CalculatedRouteList<CalcRoute> calcRoutes = new CalculatedRouteList<>();
+
+    /**
+     * Topology builder.
+     */
+    private TopologyBuilder topologyBuilder;
+
+    /**
+     * Instantiates a new TopologyNetwork builder.
+     *
+     * @param topologyBuilder    the topologyBuilder
+     * @param name the network name.
+     */
+    public NetworkBuilder(TopologyBuilder topologyBuilder, String name) {
+        this.topologyBuilder = topologyBuilder;
+        this.name = name;
+    }
+
+    /**
+     * Instantiates a new TopologyNetwork builder.
+     *
+     * @param name the network name.
+     */
+    public NetworkBuilder(String name){
+        this.name = name;
+    }
+
+    /**
+     * Add ip attribute to network.
+     *
+     * @param ip the ip
+     * @return the network builder
+     */
+    public NetworkBuilder withIP(String ip) {
+        this.ipAddress = ip;
+        return this;
+    }
+
+    /**
+     * Add mask attribute to network.
+     *
+     * @param mask the mask
+     * @return the network builder
+     */
+    public NetworkBuilder withMask(Integer mask) {
+        this.mask = mask;
+        return this;
+    }
+
+    /**
+     * Add internet attribute to network.
+     * If this network is last step between your ws and topology,
+     * network must have attribute internet sets to true!
+     *
+     * @param internet the internet
+     * @return the network builder
+     */
+    public NetworkBuilder withInternet(Boolean internet) {
+        this.internet = internet;
+        return this;
+    }
+
+    public NetworkBuilder withCreator(Object creator) {
+        this.creator = creator;
+        return this;
+    }
+
+    /**
+     * Add calcRoutes attribute to network.
+     *
+     * @param calcRoutes the calc routes
+     * @return the network builder
+     */
+    public NetworkBuilder withCalcRoutes(CalculatedRouteList<CalcRoute> calcRoutes) {
+        this.calcRoutes = calcRoutes;
+        return this;
+    }
+
+    /**
+     * Instantiates new CalcRouteBuilder used to create calcRoutes.
+     *
+     * @return new CalcRouteBuilder
+     */
+    public CalcRouteBuilder withCalcRoute(){
+        return new CalcRouteBuilder(this);
+    }
+
+
+    /**
+     * Sets docker as network creator.
+     *
+     * @return the network builder
+     */
+    public NetworkBuilder docker() {
+        this.creator = "Docker";
+        return this;
+    }
+
+    /**
+     * Builds network object.
+     *
+     * @return the network
+     */
+    public TopologyNetwork build() {
+        TopologyNetwork n = new TopologyNetwork();
+        n.setCalcRoutes(calcRoutes);
+        n.setInternet(internet);
+        n.setIPAddress(ipAddress);
+        n.setMask(mask);
+        n.setName(name);
+        n.setCreator(creator);
+        return n;
+    }
+
+    /**
+     * Builds network and adds it into topology.
+     *
+     * @return the topology builder
+     */
+    public TopologyBuilder create() {
+        if (creator == null) {
+            creator = topologyBuilder.getCurrentCreator();
+        }
+        topologyBuilder.getTopology().getNetworks().add(build());
+        return topologyBuilder;
+    }
+
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/NetworkBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/NetworkBuilder.java
@@ -17,7 +17,7 @@
 package io.patriot_framework.network_simulator.docker.builder;
 
 import io.patriot_framework.network_simulator.docker.CalculatedRouteList;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 
 /**
@@ -141,8 +141,8 @@ public class NetworkBuilder {
      *
      * @return the network
      */
-    public TopologyNetwork build() {
-        TopologyNetwork n = new TopologyNetwork();
+    public ContainerNetwork build() {
+        ContainerNetwork n = new ContainerNetwork();
         n.setCalcRoutes(calcRoutes);
         n.setInternet(internet);
         n.setIPAddress(ipAddress);

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/RouterBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/RouterBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.builder;
+
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
+
+/**
+ * The type RouterImpl builder.
+ */
+public class RouterBuilder {
+
+    public RouterBuilder(String name) {
+        this.name = name;
+    }
+
+    /**
+     * The Topology builder.
+     */
+    private TopologyBuilder topologyBuilder;
+    /**
+     * Name of router.
+     */
+    private String name;
+
+    /**
+     * Creator of object (docker, VM, ...)
+     */
+    private Object creator;
+
+    private Boolean corner = false;
+
+    /**
+     * Instantiates a new RouterImpl builder.
+     *
+     * @param topologyBuilder the topology builder
+     */
+    public RouterBuilder(TopologyBuilder topologyBuilder) {
+        this.topologyBuilder = topologyBuilder;
+    }
+
+    /**
+     * Adds name to router.
+     *
+     * @param name the name
+     * @return the router builder
+     */
+    public RouterBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public RouterBuilder withCreator(Object creator) {
+        this.creator = creator;
+        return this;
+    }
+
+    public RouterBuilder withCorner(Boolean corner) {
+        this.corner = corner;
+        return this;
+    }
+
+    /**
+     * Create new router object and add it into topology routers.
+     *
+     * @return the router builder
+     */
+    public RouterBuilder createRouter() {
+        if (creator == null) {
+            creator = topologyBuilder.getCurrentCreator();
+        }
+        topologyBuilder.getTopology().getRouters().add(new RouterImpl(name, creator, corner));
+        return this;
+    }
+
+    /**
+     * Returns TopologyBuilder with created routers.
+     *
+     * @return the topology builder
+     */
+    public TopologyBuilder addRouters() {
+        return topologyBuilder;
+    }
+
+    public Router build() {
+        RouterImpl router = new RouterImpl(name, creator, corner);
+        return router;
+    }
+
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/TopologyBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/TopologyBuilder.java
@@ -16,7 +16,7 @@
 
 package io.patriot_framework.network_simulator.docker.builder;
 
-import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.ContainerTopology;
 
 /**
  * The type Topology builder.
@@ -25,7 +25,7 @@ public class TopologyBuilder {
     /**
      * The Topology.
      */
-    private Topology topology;
+    private ContainerTopology topology;
     private Object currentCreator;
 
     public Object getCurrentCreator() {
@@ -52,10 +52,10 @@ public class TopologyBuilder {
      * @param networkCount the network count
      */
     public TopologyBuilder(int networkCount) {
-        topology = new Topology(networkCount);
+        topology = new ContainerTopology(networkCount);
     }
 
-    public TopologyBuilder(Topology topology) {
+    public TopologyBuilder(ContainerTopology topology) {
         this.topology = topology;
     }
 
@@ -64,7 +64,7 @@ public class TopologyBuilder {
      *
      * @return the topology
      */
-    public Topology build() {
+    public ContainerTopology build() {
         return topology;
     }
 
@@ -86,7 +86,7 @@ public class TopologyBuilder {
         return new RouterBuilder(this);
     }
 
-    public Topology getTopology() {
+    public ContainerTopology getTopology() {
         return topology;
     }
 }

--- a/src/main/java/io/patriot_framework/network_simulator/docker/builder/TopologyBuilder.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/builder/TopologyBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.builder;
+
+import io.patriot_framework.network_simulator.docker.model.Topology;
+
+/**
+ * The type Topology builder.
+ */
+public class TopologyBuilder {
+    /**
+     * The Topology.
+     */
+    private Topology topology;
+    private Object currentCreator;
+
+    public Object getCurrentCreator() {
+        return currentCreator;
+    }
+    public TopologyBuilder withCreator(Object creator) {
+        currentCreator = creator;
+        return this;
+    }
+
+    /**
+     * Instantiates new NetworkBuilder.
+     *
+     * @param name the network name
+     * @return the network builder
+     */
+    public NetworkBuilder withNetwork(String name) {
+        return new NetworkBuilder(this, name);
+    }
+
+    /**
+     * Instantiates a new Topology builder.
+     *
+     * @param networkCount the network count
+     */
+    public TopologyBuilder(int networkCount) {
+        topology = new Topology(networkCount);
+    }
+
+    public TopologyBuilder(Topology topology) {
+        this.topology = topology;
+    }
+
+    /**
+     * Builds topology.
+     *
+     * @return the topology
+     */
+    public Topology build() {
+        return topology;
+    }
+
+    /**
+     * Instantiates new CalcRouteBuilder.
+     *
+     * @return the calc route builder
+     */
+    public CalcRouteBuilder withRoutes() {
+        return new CalcRouteBuilder(this);
+    }
+
+    /**
+     * Instantiates new CalcRouteBuilder.
+     *
+     * @return the router builder
+     */
+    public RouterBuilder withRouters() {
+        return new RouterBuilder(this);
+    }
+
+    public Topology getTopology() {
+        return topology;
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/exceptions/UnsupportedTopologyException.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/exceptions/UnsupportedTopologyException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.exceptions;
+
+/**
+ * Class that represents exception which is thrown when unsupported Topology is passed to a method.
+ */
+public class UnsupportedTopologyException extends RuntimeException {
+    public UnsupportedTopologyException() {
+    }
+
+    public UnsupportedTopologyException(String s) {
+        super(s);
+    }
+
+    public UnsupportedTopologyException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+
+    public UnsupportedTopologyException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public UnsupportedTopologyException(String s, Throwable throwable, boolean b, boolean b1) {
+        super(s, throwable, b, b1);
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/ContainerTopology.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/ContainerTopology.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * Wrapper representing full network topology.
  */
-public class Topology {
+public class ContainerTopology {
     /**
      * Routers located in topology.
      */
@@ -63,7 +63,7 @@ public class Topology {
      * @param routers    the routers
      * @param networks the network top
      */
-    public Topology(List<Router> routers, ArrayList<ContainerNetwork> networks) {
+    public ContainerTopology(List<Router> routers, ArrayList<ContainerNetwork> networks) {
         this.routers = routers;
         this.networks = networks;
     }
@@ -73,7 +73,7 @@ public class Topology {
      *
      * @param networks the network top
      */
-    public Topology(ArrayList<ContainerNetwork> networks) {
+    public ContainerTopology(ArrayList<ContainerNetwork> networks) {
         this.networks = networks;
     }
 
@@ -82,7 +82,7 @@ public class Topology {
      *
      * @param networkCount the network count
      */
-    public Topology(Integer networkCount) {
+    public ContainerTopology(Integer networkCount) {
         this.networks = new ArrayList<>(networkCount);
     }
 
@@ -140,7 +140,7 @@ public class Topology {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Topology topology = (Topology) o;
+        ContainerTopology topology = (ContainerTopology) o;
         return getRouters().equals(topology.getRouters()) &&
                 getNetworks().equals(topology.getNetworks());
     }

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/Topology.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/Topology.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model;
+
+import io.patriot_framework.network.simulator.api.model.devices.Device;
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Wrapper representing full network topology.
+ */
+public class Topology {
+    /**
+     * Routers located in topology.
+     */
+    private List<Router> routers = new ArrayList<>();
+
+    /**
+     * Networks in topology.
+     */
+    private ArrayList<TopologyNetwork> networks;
+
+    private Set<Device> devices = new HashSet<>();
+
+    public Set<Device> getDevices() {
+        return devices;
+    }
+
+    public void setDevices(Set<Device> devices) {
+        this.devices = devices;
+    }
+
+    public void addDevice(Device d) {
+        if (devices.contains(d)) {
+            return;
+        }
+        devices.add(d);
+    }
+
+    /**
+     * Instantiates a new Topology.
+     *
+     * @param routers    the routers
+     * @param networks the network top
+     */
+    public Topology(List<Router> routers, ArrayList<TopologyNetwork> networks) {
+        this.routers = routers;
+        this.networks = networks;
+    }
+
+    /**
+     * Instantiates a new Topology.
+     *
+     * @param networks the network top
+     */
+    public Topology(ArrayList<TopologyNetwork> networks) {
+        this.networks = networks;
+    }
+
+    /**
+     * Instantiates a new Topology.
+     *
+     * @param networkCount the network count
+     */
+    public Topology(Integer networkCount) {
+        this.networks = new ArrayList<>(networkCount);
+    }
+
+    /**
+     * Gets routers.
+     *
+     * @return the routers
+     */
+    public List<Router> getRouters() {
+        return routers;
+    }
+
+    /**
+     * Sets routers.
+     *
+     * @param routers the routers
+     */
+    public void setRouters(List<Router> routers) {
+        this.routers = routers;
+    }
+
+    /**
+     * Gets network top.
+     *
+     * @return the network top
+     */
+    public ArrayList<TopologyNetwork> getNetworks() {
+        return networks;
+    }
+
+    /**
+     * Sets network top.
+     *
+     * @param networks the network top
+     */
+    public void setNetworks(ArrayList<TopologyNetwork> networks) {
+        this.networks = networks;
+    }
+
+    /**
+     * Finds router in list by name.
+     * @param name name of router
+     * @return router object
+     */
+    public Router findRouterByName(String name) {
+        for (Router r : routers) {
+            if (r.getName().equals(name)) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Topology topology = (Topology) o;
+        return getRouters().equals(topology.getRouters()) &&
+                getNetworks().equals(topology.getNetworks());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRouters(), getNetworks());
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/Topology.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/Topology.java
@@ -18,7 +18,7 @@ package io.patriot_framework.network_simulator.docker.model;
 
 import io.patriot_framework.network.simulator.api.model.devices.Device;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -38,7 +38,7 @@ public class Topology {
     /**
      * Networks in topology.
      */
-    private ArrayList<TopologyNetwork> networks;
+    private ArrayList<ContainerNetwork> networks;
 
     private Set<Device> devices = new HashSet<>();
 
@@ -63,7 +63,7 @@ public class Topology {
      * @param routers    the routers
      * @param networks the network top
      */
-    public Topology(List<Router> routers, ArrayList<TopologyNetwork> networks) {
+    public Topology(List<Router> routers, ArrayList<ContainerNetwork> networks) {
         this.routers = routers;
         this.networks = networks;
     }
@@ -73,7 +73,7 @@ public class Topology {
      *
      * @param networks the network top
      */
-    public Topology(ArrayList<TopologyNetwork> networks) {
+    public Topology(ArrayList<ContainerNetwork> networks) {
         this.networks = networks;
     }
 
@@ -109,7 +109,7 @@ public class Topology {
      *
      * @return the network top
      */
-    public ArrayList<TopologyNetwork> getNetworks() {
+    public ArrayList<ContainerNetwork> getNetworks() {
         return networks;
     }
 
@@ -118,7 +118,7 @@ public class Topology {
      *
      * @param networks the network top
      */
-    public void setNetworks(ArrayList<TopologyNetwork> networks) {
+    public void setNetworks(ArrayList<ContainerNetwork> networks) {
         this.networks = networks;
     }
 

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/NetworkInterface.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/NetworkInterface.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.devices.router;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Router' s network interface.
+ *
+ * Is used for representation of physical interface of router (Container / VM).
+ * Contains only most necessary informations about physical interface.
+ *
+ */
+public class NetworkInterface {
+    /**
+     * The Name.
+     */
+    @JsonProperty("Name")
+    private String name;
+    /**
+     * The Ip.
+     */
+    @JsonProperty("IPAddress")
+    private String ip;
+    /**
+     * The Mask.
+     */
+    private Integer mask;
+
+    public NetworkInterface(String name, String ip) {
+        this.name = name;
+        this.ip = ip;
+    }
+
+    public NetworkInterface(String ip) {
+        this.ip = ip;
+    }
+
+    /**
+     * Instantiates a new TopologyNetwork interface.
+     *
+     * @param name the network name
+     * @param ip   the ip address
+     * @param mask the mask
+     */
+    public NetworkInterface(String name, String ip, Integer mask) {
+        this.name = name;
+        this.ip = ip;
+        this.mask = mask;
+    }
+
+    /**
+     * Instantiates a new TopologyNetwork interface.
+     */
+    public NetworkInterface() {
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets ip.
+     *
+     * @return the ip
+     */
+    public String getIp() {
+        return ip;
+    }
+
+    /**
+     * Sets ip.
+     *
+     * @param ip the ip
+     */
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    /**
+     * Gets mask.
+     *
+     * @return the mask
+     */
+    public Integer getMask() {
+        return mask;
+    }
+
+    /**
+     * Sets mask.
+     *
+     * @param mask the mask
+     */
+    public void setMask(Integer mask) {
+        this.mask = mask;
+    }
+
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/Router.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/Router.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.devices.router;
+
+import io.patriot_framework.network.simulator.api.model.devices.Device;
+
+import java.util.List;
+
+public interface Router extends Device {
+    /**
+     * Returns physical network interfaces of router.
+     * @return list of connected interfaces
+     */
+    List<NetworkInterface> getInterfaces();
+    void setNetworkInterfaces(List<NetworkInterface> networkInterfaces);
+
+
+    /**
+     * Returns if this router is last step to internet in current LAN.
+     * @return true if router is on border, false otherwise
+     */
+    Boolean isCorner();
+
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/RouterImpl.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/RouterImpl.java
@@ -216,7 +216,7 @@ public class RouterImpl implements Router {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        io.patriot_framework.network.simulator.api.model.devices.router.RouterImpl router = (io.patriot_framework.network.simulator.api.model.devices.router.RouterImpl) o;
+        RouterImpl router = (RouterImpl) o;
         return corner == router.corner &&
                 getName().equals(router.getName()) &&
                 Objects.equals(getNetworkInterfaces(), router.getNetworkInterfaces()) &&

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/RouterImpl.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/devices/router/RouterImpl.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.devices.router;
+
+import io.patriot_framework.network.simulator.api.model.network.Network;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * RouterImpl class represents docker container built as router with network-control apis.
+ */
+public class RouterImpl implements Router {
+    private String name;
+    private List<NetworkInterface> networkInterfaces;
+    private List<Network> connectedTopologyNetworks = new ArrayList<>();
+    private String managementIP;
+    private Integer managementPort = 0;
+    private Object creator;
+    private boolean corner = false;
+
+
+    // Default go iproute2 rest api http port
+    public static final int DEFAULT_PORT = 8090;
+
+    /**
+     * Instantiates a new RouterImpl.
+     *
+     * @param name the name
+     */
+    public RouterImpl(String name) {
+        this.name = name;
+        connectedTopologyNetworks = new ArrayList<>();
+    }
+
+    public RouterImpl(String name, Object creator) {
+        this.creator = creator;
+        this.name = name;
+    }
+
+    /**
+     * Instantiates a new RouterImpl.
+     *
+     * @param name              the name
+     * @param networkInterfaces the network interfaces
+     */
+    public RouterImpl(String name, List<NetworkInterface> networkInterfaces) {
+        this.name = name;
+        this.networkInterfaces = networkInterfaces;
+    }
+
+    public RouterImpl(String name, Object creator, boolean corner) {
+        this.name = name;
+        this.creator = creator;
+        this.corner = corner;
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public List<NetworkInterface> getInterfaces() {
+        return networkInterfaces;
+    }
+
+
+    @Override
+    public String getIPAddress() {
+        return managementIP;
+    }
+
+    @Override
+    public void setIPAddress(String ipAddress) {
+        this.managementIP = ipAddress;
+    }
+
+    @Override
+    public List<Network> getConnectedNetworks() {
+        return connectedTopologyNetworks;
+    }
+
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets network interfaces.
+     *
+     * @return the network interfaces
+     */
+    public List<NetworkInterface> getNetworkInterfaces() {
+        return networkInterfaces;
+    }
+
+    /**
+     * Sets network interfaces.
+     *
+     * @param networkInterfaces the network interfaces
+     */
+    public void setNetworkInterfaces(List<NetworkInterface> networkInterfaces) {
+        this.networkInterfaces = networkInterfaces;
+    }
+
+    /**
+     * Gets connected networks.
+     *
+     * @return the connected networks
+     */
+    public List<Network> getConnectedTopologyNetworks() {
+        return connectedTopologyNetworks;
+    }
+
+    /**
+     * Sets connected networks.
+     *
+     * @param connectedTopologyNetworks the connected networks
+     */
+    public void setConnectedTopologyNetworks(List<Network> connectedTopologyNetworks) {
+        this.connectedTopologyNetworks = connectedTopologyNetworks;
+    }
+
+    /**
+     * Gets mng ip.
+     *
+     * @return the mng ip
+     */
+    public String getManagementIP() {
+        return managementIP;
+    }
+
+    /**
+     * Sets mng ip.
+     *
+     * @param managementIP the mng ip
+     */
+    public void setManagementIP(String managementIP) {
+        this.managementIP = managementIP;
+    }
+
+    /**
+     * Gets mng port.
+     *
+     * @return the mng port
+     */
+    public Integer getManagementPort() {
+        if (managementPort == 0) {
+            return DEFAULT_PORT;
+        }
+        return managementPort;
+    }
+
+    /**
+     * Sets mng port.
+     *
+     * @param managementPort the mng port
+     */
+    public void setManagementPort(Integer managementPort) {
+        this.managementPort = managementPort;
+    }
+
+    @Override
+    public Boolean isCorner() {
+        return corner;
+    }
+
+    public void setCorner(Boolean corner) {
+        this.corner = corner;
+    }
+
+    @Override
+    public Object getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    @Override
+    public String getAddressForNetwork(String networkName) {
+        return null;
+    }
+
+    @Override
+    public boolean addAddressForNetwork(String address, String networkName) {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        io.patriot_framework.network.simulator.api.model.devices.router.RouterImpl router = (io.patriot_framework.network.simulator.api.model.devices.router.RouterImpl) o;
+        return corner == router.corner &&
+                getName().equals(router.getName()) &&
+                Objects.equals(getNetworkInterfaces(), router.getNetworkInterfaces()) &&
+                getConnectedTopologyNetworks().equals(router.getConnectedTopologyNetworks()) &&
+                Objects.equals(getManagementIP(), router.getManagementIP()) &&
+                Objects.equals(getManagementPort(), router.getManagementPort()) &&
+                getCreator().equals(router.getCreator());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getNetworkInterfaces(), getConnectedTopologyNetworks(), getManagementIP(), getManagementPort(), getCreator(), corner);
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/network/ContainerNetwork.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/network/ContainerNetwork.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * TopologyNetwork class representing docker network with additional informations
  * like calculated routes to other networks.
  */
-public class TopologyNetwork extends Network {
+public class ContainerNetwork extends Network {
 
     @JsonIgnore
     private CalculatedRouteList<CalcRoute> calcRoutes = new CalculatedRouteList<>();
@@ -41,7 +41,7 @@ public class TopologyNetwork extends Network {
     /**
      * Instantiates a new TopologyNetwork.
      */
-    public TopologyNetwork() {
+    public ContainerNetwork() {
     }
 
     /**
@@ -50,7 +50,7 @@ public class TopologyNetwork extends Network {
      * @param calcRoutes the calc routes
      * @param name       the name
      */
-    public TopologyNetwork(CalculatedRouteList<CalcRoute> calcRoutes, String name) {
+    public ContainerNetwork(CalculatedRouteList<CalcRoute> calcRoutes, String name) {
         this.calcRoutes = calcRoutes;
         super.setName(name);
     }
@@ -60,7 +60,7 @@ public class TopologyNetwork extends Network {
      *
      * @param calcRoutes the calc routes
      */
-    public TopologyNetwork(CalculatedRouteList<CalcRoute> calcRoutes) {
+    public ContainerNetwork(CalculatedRouteList<CalcRoute> calcRoutes) {
         this.calcRoutes = calcRoutes;
     }
 
@@ -112,13 +112,13 @@ public class TopologyNetwork extends Network {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        TopologyNetwork that = (TopologyNetwork) o;
+        ContainerNetwork that = (ContainerNetwork) o;
         return calcRoutes.equals(that.calcRoutes) &&
                 internet.equals(that.internet) &&
                 creator.equals(that.creator) &&
-                this.getName().equals(((TopologyNetwork) o).getName()) &&
-                this.getIPAddress().equals(((TopologyNetwork) o).getIPAddress()) &&
-                this.getMask().equals(((TopologyNetwork) o).getMask());
+                this.getName().equals(((ContainerNetwork) o).getName()) &&
+                this.getIPAddress().equals(((ContainerNetwork) o).getIPAddress()) &&
+                this.getMask().equals(((ContainerNetwork) o).getMask());
     }
 
     @Override

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/network/TopologyNetwork.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/network/TopologyNetwork.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.network;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.patriot_framework.network.simulator.api.model.network.Network;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+
+import java.util.Objects;
+
+/**
+ * TopologyNetwork class representing docker network with additional informations
+ * like calculated routes to other networks.
+ */
+public class TopologyNetwork extends Network {
+
+    @JsonIgnore
+    private CalculatedRouteList<CalcRoute> calcRoutes = new CalculatedRouteList<>();
+    @JsonIgnore
+    private Boolean internet = false;
+    @JsonIgnore
+    private Object creator;
+    @JsonIgnore
+    private String internetInterfaceIP = null;
+
+    /**
+     * Instantiates a new TopologyNetwork.
+     */
+    public TopologyNetwork() {
+    }
+
+    /**
+     * Instantiates a new TopologyNetwork.
+     *
+     * @param calcRoutes the calc routes
+     * @param name       the name
+     */
+    public TopologyNetwork(CalculatedRouteList<CalcRoute> calcRoutes, String name) {
+        this.calcRoutes = calcRoutes;
+        super.setName(name);
+    }
+
+    /**
+     * Instantiates a new TopologyNetwork.
+     *
+     * @param calcRoutes the calc routes
+     */
+    public TopologyNetwork(CalculatedRouteList<CalcRoute> calcRoutes) {
+        this.calcRoutes = calcRoutes;
+    }
+
+    /**
+     * Gets calc routes.
+     *
+     * @return the calc routes
+     */
+    public CalculatedRouteList<CalcRoute> getCalcRoutes() {
+        return calcRoutes;
+    }
+
+    /**
+     * Sets calc routes.
+     *
+     * @param calcRoutes the calc routes
+     */
+    public void setCalcRoutes(CalculatedRouteList<CalcRoute> calcRoutes) {
+        this.calcRoutes = calcRoutes;
+    }
+
+    public Boolean getInternet() {
+        return internet;
+    }
+
+    public void setInternet(Boolean internet) {
+        this.internet = internet;
+    }
+
+
+    public void setCreator(Object creator) {
+        this.creator = creator;
+    }
+
+    @Override
+    public Object getCreator() {
+        return creator;
+    }
+
+    public String getInternetInterfaceIP() {
+        return internetInterfaceIP;
+    }
+
+    public void setInternetInterfaceIP(String internetInterfaceIP) {
+        this.internetInterfaceIP = internetInterfaceIP;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TopologyNetwork that = (TopologyNetwork) o;
+        return calcRoutes.equals(that.calcRoutes) &&
+                internet.equals(that.internet) &&
+                creator.equals(that.creator) &&
+                this.getName().equals(((TopologyNetwork) o).getName()) &&
+                this.getIPAddress().equals(((TopologyNetwork) o).getIPAddress()) &&
+                this.getMask().equals(((TopologyNetwork) o).getMask());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCalcRoutes(), getInternet(), getCreator(), getInternetInterfaceIP());
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/network/TopologyNetwork.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/network/TopologyNetwork.java
@@ -18,6 +18,7 @@ package io.patriot_framework.network_simulator.docker.model.network;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.patriot_framework.network.simulator.api.model.network.Network;
+import io.patriot_framework.network_simulator.docker.CalculatedRouteList;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 
 import java.util.Objects;

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/CalcRoute.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/CalcRoute.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.routes;
+
+
+import java.util.Objects;
+
+/**
+ * Calculated route. Including all necessary info to describe routes.
+ */
+public class CalcRoute {
+    private NextHop nextHop;
+    private Integer cost;
+
+    /**
+     * Instantiates a new Calc route.
+     *
+     * @param nextHop the next hop
+     * @param cost    the cost
+     */
+    public CalcRoute(NextHop nextHop, Integer cost) {
+        this.nextHop = nextHop;
+        this.cost = cost;
+    }
+
+    /**
+     * Gets next hop.
+     *
+     * @return the next hop
+     */
+    public NextHop getNextHop() {
+        return nextHop;
+    }
+
+    /**
+     * Sets next hop.
+     *
+     * @param nextHop the next hop
+     */
+    public void setNextHop(NextHop nextHop) {
+        this.nextHop = nextHop;
+    }
+
+    /**
+     * Gets cost.
+     *
+     * @return the cost
+     */
+    public Integer getCost() {
+        return cost;
+    }
+
+    /**
+     * Sets cost.
+     *
+     * @param cost the cost
+     */
+    public void setCost(Integer cost) {
+        this.cost = cost;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CalcRoute calcRoute = (CalcRoute) o;
+        return getNextHop().equals(calcRoute.getNextHop()) &&
+                Objects.equals(getCost(), calcRoute.getCost());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getNextHop(), getCost());
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/NextHop.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/NextHop.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.routes;
+
+
+import java.util.Objects;
+
+/**
+ * Wrapper class for RouterImpl and network. Representing next hop in the network topology.
+ */
+public class NextHop {
+    private Router router;
+    private Integer network;
+
+    /**
+     * Instantiates a new Next hop.
+     *
+     * @param router  the router
+     * @param network the network
+     */
+    public NextHop(Router router, Integer network) {
+        this.router = router;
+        this.network = network;
+    }
+
+    /**
+     * Gets router.
+     *
+     * @return the router
+     */
+    public Router getRouter() {
+        return router;
+    }
+
+    /**
+     * Sets router.
+     *
+     * @param router the router
+     */
+    public void setRouter(Router router) {
+        this.router = router;
+    }
+
+    /**
+     * Gets network.
+     *
+     * @return the network
+     */
+    public Integer getNetwork() {
+        return network;
+    }
+
+    /**
+     * Sets network.
+     *
+     * @param network the network
+     */
+    public void setNetwork(Integer network) {
+        this.network = network;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NextHop nextHop = (NextHop) o;
+        return Objects.equals(getRouter(), nextHop.getRouter()) &&
+                getNetwork().equals(nextHop.getNetwork());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRouter(), getNetwork());
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/NextHop.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/NextHop.java
@@ -17,6 +17,8 @@
 package io.patriot_framework.network_simulator.docker.model.routes;
 
 
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+
 import java.util.Objects;
 
 /**

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.model.routes;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Used for represent route record in routing tables.
+ */
+public class Route {
+
+    @JsonIgnore
+    private TopologyNetwork source;
+
+    @JsonIgnore
+    private Router targetRouter;
+
+    @JsonIgnore
+    private Integer mtu = 1400;
+
+    @JsonIgnore
+    private Integer hopLimit = 16;
+
+    @JsonProperty("Destination")
+    private TopologyNetwork dest;
+
+    @JsonProperty("InterfaceIP")
+    private NetworkInterface rNetworkInterface;
+
+    public Route() {
+    }
+
+    /**
+     * Gets dest.
+     *
+     * @return the dest
+     */
+    public TopologyNetwork getDest() {
+        return dest;
+    }
+
+    /**
+     * Sets dest.
+     *
+     * @param dest the dest
+     */
+    public void setDest(TopologyNetwork dest) {
+        this.dest = dest;
+    }
+
+    /**
+     * Gets source.
+     *
+     * @return the source
+     */
+    public TopologyNetwork getSource() {
+        return source;
+    }
+
+    /**
+     * Sets source.
+     *
+     * @param source the source
+     */
+    public void setSource(TopologyNetwork source) {
+        this.source = source;
+    }
+
+    /**
+     * Gets network interface.
+     *
+     * @return the network interface
+     */
+    public NetworkInterface getrNetworkInterface() {
+        return rNetworkInterface;
+    }
+
+    /**
+     * Sets network interface.
+     *
+     * @param rNetworkInterface the r network interface
+     */
+    public void setrNetworkInterface(NetworkInterface rNetworkInterface) {
+        this.rNetworkInterface = rNetworkInterface;
+    }
+
+    /**
+     * Gets target router.
+     *
+     * @return the target router
+     */
+    public Router getTargetRouter() {
+        return targetRouter;
+    }
+
+    /**
+     * Sets target router.
+     *
+     * @param targetRouter the target router
+     */
+    public void setTargetRouter(Router targetRouter) {
+        this.targetRouter = targetRouter;
+    }
+
+    /**
+     * To path string.
+     *
+     * @return the string
+     */
+    public String toAPIFormat() {
+        return "destination=" + getDest().getIPAddress() + "&mask=" + getDest().getMask() + "&interface=" + rNetworkInterface.getIp();
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
 
 /**
  * Used for represent route record in routing tables.

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
@@ -18,6 +18,8 @@ package io.patriot_framework.network_simulator.docker.model.routes;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 
 /**
  * Used for represent route record in routing tables.

--- a/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/model/routes/Route.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 
 /**
  * Used for represent route record in routing tables.
@@ -28,7 +28,7 @@ import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwo
 public class Route {
 
     @JsonIgnore
-    private TopologyNetwork source;
+    private ContainerNetwork source;
 
     @JsonIgnore
     private Router targetRouter;
@@ -40,7 +40,7 @@ public class Route {
     private Integer hopLimit = 16;
 
     @JsonProperty("Destination")
-    private TopologyNetwork dest;
+    private ContainerNetwork dest;
 
     @JsonProperty("InterfaceIP")
     private NetworkInterface rNetworkInterface;
@@ -53,7 +53,7 @@ public class Route {
      *
      * @return the dest
      */
-    public TopologyNetwork getDest() {
+    public ContainerNetwork getDest() {
         return dest;
     }
 
@@ -62,7 +62,7 @@ public class Route {
      *
      * @param dest the dest
      */
-    public void setDest(TopologyNetwork dest) {
+    public void setDest(ContainerNetwork dest) {
         this.dest = dest;
     }
 
@@ -71,7 +71,7 @@ public class Route {
      *
      * @return the source
      */
-    public TopologyNetwork getSource() {
+    public ContainerNetwork getSource() {
         return source;
     }
 
@@ -80,7 +80,7 @@ public class Route {
      *
      * @param source the source
      */
-    public void setSource(TopologyNetwork source) {
+    public void setSource(ContainerNetwork source) {
         this.source = source;
     }
 

--- a/src/main/java/io/patriot_framework/network_simulator/docker/topology/ContainerTopologyManager.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/topology/ContainerTopologyManager.java
@@ -1,0 +1,616 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker.topology;
+
+import com.github.jgonian.ipmath.Ipv4;
+import com.github.jgonian.ipmath.Ipv4Range;
+import io.patriot_framework.network.simulator.api.control.Controller;
+import io.patriot_framework.network.simulator.api.model.EnvironmentPart;
+import io.patriot_framework.network.simulator.api.model.devices.Device;
+import io.patriot_framework.network_simulator.docker.api.iproute.RouteRestController;
+import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
+import io.patriot_framework.network_simulator.docker.model.routes.Route;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ContainerTopologyManager {
+    private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    private List<Controller> controllers;
+    private String monitoringAddr;
+    private String routerTag;
+    private int monitoringPort = 0;
+    private HashMap<String, ArrayList<Route>> processedRoutes = new HashMap<>();
+
+
+    /**
+     * Constructor
+     *
+     * @param routerTag tag of router to be used
+     */
+    public ContainerTopologyManager(String routerTag) {
+        this.routerTag = routerTag;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param controllers to be used
+     */
+    public ContainerTopologyManager(List<Controller> controllers) {
+        this.controllers = controllers;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param controllers to be used
+     * @param routerTag   tag of the router
+     */
+    public ContainerTopologyManager(List<Controller> controllers, String routerTag) {
+        this.controllers = controllers;
+        this.routerTag = routerTag;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param controllers    controllers used by manager
+     * @param routerTag      tag of router image
+     * @param monitoringAddr ip address of monitoring service
+     * @param monitoringPort port of monitoring service
+     */
+    public ContainerTopologyManager(List<Controller> controllers, String routerTag, String monitoringAddr, int monitoringPort) {
+        this.controllers = controllers;
+        this.monitoringAddr = monitoringAddr;
+        this.routerTag = routerTag;
+        this.monitoringPort = monitoringPort;
+    }
+
+
+    /**
+     * Getter for monitoring address
+     *
+     * @return address of monitoring component
+     */
+    public String getMonitoringAddr() {
+        return monitoringAddr;
+    }
+
+    /**
+     * Setter for monitoring address
+     *
+     * @param monitoringAddr Address of monitoring service (greylog)
+     * @param monitoringPort port of monitoring service
+     */
+    public void setMonitoring(String monitoringAddr, int monitoringPort) {
+        this.monitoringAddr = monitoringAddr;
+        this.monitoringPort = monitoringPort;
+    }
+
+    /**
+     * Setter for controllers
+     * @param controllers controllers to be used by manager
+     */
+    public void setControllers(List<Controller> controllers) {
+        this.controllers = controllers;
+    }
+
+
+
+    /**
+     * Deploy all topology. Creates all virtual devices (routers), networks. Connect them as topology describes.
+     * Calculate routes and set them to routes.
+     *
+     * @param topology
+     */
+    public void deployTopology(Topology topology) {
+        createNetworks(topology.getNetworks());
+        createRouters(topology);
+        connectNetworks(topology);
+        updateRouters(topology);
+        calcRoutes(topology);
+        processRoutes(topology);
+        setRoutes(topology);
+        setMasquerade(topology);
+    }
+
+    /**
+     * Getter for processed routes
+     *
+     * @return refined routes after application of rules
+     */
+    public HashMap<String, ArrayList<Route>> getProcessedRoutes() {
+        return processedRoutes;
+    }
+
+    /**
+     * Calculates routers via Floyd-Warshall algo.
+     *
+     * @param topology the representation of topology where shortest paths are to be found
+     */
+    public void calcRoutes(Topology topology) {
+        ArrayList<TopologyNetwork> topologyNetworks = topology.getNetworks();
+        LOGGER.info("Calculating network routes.");
+        int size = topologyNetworks.size();
+
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                for (int k = 0; k < size; k++) {
+                    if (i == k || i == j || j == k) {
+                        continue;
+                    }
+                    int cost = topologyNetworks.get(i).getCalcRoutes().get(j).getCost()
+                            + topologyNetworks.get(j).getCalcRoutes().get(k).getCost();
+                    int actualCost = topologyNetworks.get(i).getCalcRoutes().get(k).getCost();
+
+                    if (actualCost == (size + 1) || actualCost > cost) {
+                        swapCalcRoutes(topologyNetworks, i, j, k);
+                    }
+                }
+            }
+        }
+    }
+
+    private void swapCalcRoutes(ArrayList<TopologyNetwork> topologyNetworks, int i, int j, int k) {
+        NextHop nextHop = new NextHop(topologyNetworks.get(i).getCalcRoutes()
+                .get(j).getNextHop().getRouter(),
+                topologyNetworks.get(i).getCalcRoutes().get(j).getNextHop().getNetwork());
+
+        CalcRoute c = new CalcRoute(nextHop, topologyNetworks.get(i).getCalcRoutes().get(j).getCost()
+                + topologyNetworks.get(j).getCalcRoutes().get(k).getCost());
+        topologyNetworks.get(i).getCalcRoutes().set(k, c);
+    }
+
+
+    /**
+     * Parses calculated routes to actual route objects.
+     *
+     * @param topology topology of network
+     */
+    public void processRoutes(Topology topology) {
+        LOGGER.info("Processing routes to ipRoute2 format.");
+        ArrayList<TopologyNetwork> calculatedTop = topology.getNetworks();
+        int size = calculatedTop.size();
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < calculatedTop.get(i).getCalcRoutes().size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+
+                Router r = calculatedTop.get(i).getCalcRoutes().get(j).getNextHop().getRouter();
+                Router iRouter = selectNextHopRouter(calculatedTop, i, j);
+                Route route = completeRoute(calculatedTop, r, iRouter, i, j);
+                updateProcessedRoutes(route, r);
+            }
+        }
+    }
+
+    /**
+     * Completes route object.
+     *
+     * @param topologyNetworks networks
+     * @param r                router
+     * @param i                source network index
+     * @param j                destination network index
+     * @return complete route object with all attributes
+     */
+    private Route completeRoute(ArrayList<TopologyNetwork> topologyNetworks, Router r, Router nextHopRouter, int i, int j) {
+        Route route = new Route();
+
+        route.setTargetRouter(r);
+
+        route.setSource(topologyNetworks.get(i));
+        route.setDest(topologyNetworks.get(j));
+
+        int nextNetwork = topologyNetworks.get(i).getCalcRoutes().get(j).getNextHop().getNetwork();
+        NetworkInterface target;
+        if (nextHopRouter == null) {
+            target = new NetworkInterface(topologyNetworks.get(j).getInternetInterfaceIP());
+        } else {
+            target = findCorrectInterface(nextHopRouter, topologyNetworks.get(nextNetwork));
+        }
+        route.setrNetworkInterface(target);
+        return route;
+    }
+
+    /**
+     * Finds next hop router. If router last step to dest network func returns actual nexthop
+     * router if not func returns nexthop + 1 router.
+     *
+     * @param calculatedTop
+     * @param actualNet
+     * @param destNet
+     * @return
+     */
+    private Router selectNextHopRouter(ArrayList<TopologyNetwork> calculatedTop, int actualNet, int destNet) {
+        if (calculatedTop.get(actualNet).getCalcRoutes().get(destNet).getCost() == 1 && calculatedTop.get(destNet).getInternet()) {
+            return null;
+        } else if ((calculatedTop.get(actualNet).getCalcRoutes().get(destNet).getCost() - 1) != 0) {
+            int nextHopNetwork = calculatedTop.get(actualNet).getCalcRoutes().get(destNet).getNextHop().getNetwork();
+            return calculatedTop.get(nextHopNetwork).getCalcRoutes().get(destNet).getNextHop().getRouter();
+        } else {
+            return calculatedTop.get(actualNet).getCalcRoutes().get(destNet).getNextHop().getRouter();
+        }
+    }
+
+    /**
+     * Checks if route not processed yet, if not puts it into routes map.
+     *
+     * @param route
+     * @param r
+     */
+    private void updateProcessedRoutes(Route route, Router r) {
+        if (!processedRoutes.containsKey(r.getName())) {
+            processedRoutes.put(r.getName(), new ArrayList<>(Arrays.asList(route)));
+        } else {
+            if (isProcessedRoute(processedRoutes.get(r.getName()), route)) {
+                return;
+            }
+            processedRoutes.get(r.getName()).add(route);
+        }
+    }
+
+
+    /**
+     * Finds correct network interface on router for target network.
+     *
+     * @param source
+     * @param topologyNetwork
+     * @return network interface which is in target network
+     */
+    private NetworkInterface findCorrectInterface(Router source, TopologyNetwork topologyNetwork) {
+        LOGGER.info("Finding correct interface for " + topologyNetwork.getName() + " on " + source.getName());
+        Ipv4Range range = Ipv4Range.parse(topologyNetwork.getIPAddress() + "/" + topologyNetwork.getMask());
+
+        for (int i = 0; i < source.getInterfaces().size(); i++) {
+            if (range.contains(Ipv4.of(source.getInterfaces().get(i).getIp()))) {
+                LOGGER.debug("Found correct interface: " + source.getInterfaces().get(i));
+                return source.getInterfaces().get(i);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if route is already present in list.
+     *
+     * @param routes
+     * @param route
+     * @return true if route is present
+     */
+    private boolean isProcessedRoute(ArrayList<Route> routes, Route route) {
+        for (Route r : routes) {
+            if (r.getDest() == route.getDest() && r.getrNetworkInterface() == route.getrNetworkInterface()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Sets routes to routing table via REST API on targeted routers.
+     *
+     * @param topology topology of network
+     */
+    public void setRoutes(Topology topology) {
+        RouteRestController routeController = new RouteRestController();
+        for (Map.Entry<String, ArrayList<Route>> entry : processedRoutes.entrySet()) {
+            Router r = topology.findRouterByName(entry.getKey());
+            LOGGER.info("Setting routes to routing table on " + r.getName());
+
+            for (Route route : entry.getValue()) {
+                if (route.getDest().getInternet()) {
+                    LOGGER.info("Setting default route");
+                    routeController.delDefaultGw(r.getIPAddress(), r.getManagementPort());
+                    routeController.addDefaultGW(route, r.getIPAddress(), r.getManagementPort());
+                } else {
+                    routeController.addRoute(route, r.getIPAddress(), r.getManagementPort());
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Method updates interfaces of routers. Usually have to be called after
+     * routers are connected to networks.
+     *
+     * @param topology topology of network
+     */
+    private void updateRouters(Topology topology) {
+        RouteRestController restController = new RouteRestController();
+        LOGGER.info("Requesting information about routers interfaces.");
+        for (Router r : topology.getRouters()) {
+            r.setNetworkInterfaces(restController.getInterfaces(r.getIPAddress(), r.getManagementPort()));
+        }
+    }
+
+    /**
+     * Connects networks as topology describes.
+     *
+     * @param topology
+     */
+    private void connectNetworks(Topology topology) {
+        LOGGER.info("Initializing corner network address");
+        initializeCornerNetworkIP(topology);
+        LOGGER.info("Connecting networks.");
+        HashMap<String, List<TopologyNetwork>> directConnections = filterConnected(topology);
+        for (Map.Entry<String, List<TopologyNetwork>> entry : directConnections.entrySet()) {
+            Router r = topology.findRouterByName(entry.getKey());
+            Controller controller = findController(r);
+            for (TopologyNetwork network : entry.getValue()) {
+                LOGGER.info("Connecting router " + r.getName() + "with " + network.getName());
+                if (!network.getInternet()) {
+                    controller.connectDeviceToNetwork(r, network);
+                    r.getConnectedNetworks().add(network);
+                }
+            }
+        }
+    }
+
+    /**
+     * Initializes ip address last hop in current LAN.
+     *
+     * @param topology topology of network
+     */
+    private void initializeCornerNetworkIP(Topology topology) {
+        for (TopologyNetwork n : topology.getNetworks()) {
+            if (n.getInternet()) {
+                Device device = findDeviceWithCreator(topology, n.getCreator());
+                Controller controller = findController(device);
+                n.setInternetInterfaceIP(controller.findGWIPAddress(device));
+                n.setIPAddress(controller.findGWNetworkIPAddress(device));
+                n.setMask(controller.findGWMask(device));
+            }
+        }
+    }
+
+    /**
+     * Returns device with created by target creator.
+     *
+     * @param topology topology of network
+     * @param creator  creating object
+     * @return
+     */
+    private Device findDeviceWithCreator(Topology topology, Object creator) {
+        for (Device device : topology.getRouters()) {
+            if (device.getCreator().equals(creator)) {
+                return device;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Method provides filtering of networks which have to be physically connected
+     * to other network via router, as it's described in topology.
+     *
+     * @param topology
+     * @return Hash map with router`s name as key and networks with which router has to be connected
+     */
+    private HashMap<String, List<TopologyNetwork>> filterConnected(Topology topology) {
+        LOGGER.info("Filtering direct connections.");
+        HashMap<String, List<TopologyNetwork>> connections = new HashMap<>();
+
+        int topologySize = topology.getNetworks().size();
+        ArrayList<TopologyNetwork> networks = topology.getNetworks();
+
+        for (int i = 0; i < topologySize; i++) {
+            TopologyNetwork network = networks.get(i);
+            for (int y = 0; y < network.getCalcRoutes().size(); y++) {
+                if (i == y) continue;
+                CalcRoute calcRoute = network.getCalcRoutes().get(y);
+                if (calcRoute.getCost() == 1) {
+                    String rName = calcRoute.getNextHop().getRouter().getName();
+                    TopologyNetwork dNetwork = networks.get(calcRoute.getNextHop().getNetwork());
+                    connectionExists(rName, new ArrayList<>(Arrays.asList(network, dNetwork)), connections);
+                }
+            }
+        }
+        return connections;
+    }
+
+    /**
+     * Method checks if target networks are stored in connections array. If not, they are inserted into connections
+     * map, if router name is already stored in map, method checks if networks are stored too. If they are not
+     * present, value is updated.
+     *
+     * @param rName
+     * @param networks
+     * @param connections
+     */
+    private void connectionExists(String rName, List<TopologyNetwork> networks, HashMap<String, List<TopologyNetwork>> connections) {
+        LOGGER.debug("Controlling if direct connection is already stored.");
+        if (connections.keySet().contains(rName)) {
+            for (int i = 0; i < 2; i++) {
+                if (!connections.get(rName).contains(networks.get(i))) {
+                    connections.get(rName).add(networks.get(i));
+                }
+            }
+        } else {
+            connections.put(rName, networks);
+        }
+    }
+
+    /**
+     * Creates networks.
+     *
+     * @param networkList
+     */
+    private void createNetworks(ArrayList<TopologyNetwork> networkList) {
+        for (TopologyNetwork network : networkList) {
+            if (!network.getInternet()) {
+                LOGGER.debug("Creating network: " + network.getName());
+                findController(network).createNetwork(network);
+            }
+        }
+    }
+
+    /**
+     * Creates routers and updates mng IP.
+     *
+     * @param topology
+     */
+    private void createRouters(Topology topology) {
+        for (Router router : topology.getRouters()) {
+            LOGGER.debug("Creating router: " + router.getName());
+            if (monitoringAddr != null && monitoringPort != 0) {
+                findController(router).deployDevice(router, routerTag, monitoringAddr, monitoringPort);
+            } else {
+                findController(router).deployDevice(router, routerTag);
+            }
+
+        }
+    }
+
+    /**
+     * Finds controller by an object identifier. If the controller consists of multiple other controllers, it will check with them too.
+     * For 'Docker' will return Docker implementation of controller.
+     *
+     * @param environmentPart part of creating environment like network, router, ...
+     * @return
+     */
+    private Controller findController(EnvironmentPart environmentPart) {
+        for (Controller masterController : controllers) {
+            Collection<Controller> controllers = masterController.getSubControllers().orElse(Collections.singleton(masterController));
+            for (Controller controller : controllers) {
+                if (environmentPart.getCreator().equals(controller.getIdentifier())) {
+                    LOGGER.debug("Found right controller for: " + environmentPart.getCreator());
+                    return controller;
+                }
+            }
+        }
+        LOGGER.error("Cannot find matching creator!");
+        return null;
+    }
+
+    /**
+     * Clean all routers, networks in topology (stop and delete).
+     *
+     * @param topology
+     */
+    public void cleanUp(Topology topology) {
+        Controller controller;
+        for (Router r : topology.getRouters()) {
+            controller = findController(r);
+            LOGGER.info("Destroying router " + r.getName());
+            controller.destroyDevice(r);
+        }
+        for (Device device : topology.getDevices()) {
+            controller = findController(device);
+            LOGGER.info("Destroying device " + device.getName());
+            controller.destroyDevice(device);
+        }
+        for (TopologyNetwork n : topology.getNetworks()) {
+            if (!n.getInternet()) {
+                controller = findController(n);
+                LOGGER.info("Destroying network " + n.getName());
+                controller.destroyNetwork(n);
+            }
+        }
+    }
+
+    /**
+     * Deploys device to selected environment.
+     *
+     * @param device the device
+     * @param tag    the tag
+     */
+    public void deployDevice(Device device, String tag) {
+        findController(device).deployDevice(device, tag);
+    }
+
+    /**
+     * Sets masquerade to iptables on corner router, which provides full
+     * connectivity to internet for all networks communicating with corner router.
+     *
+     * @param topology topology of network
+     */
+    public void setMasquerade(Topology topology) {
+        for (Router r : topology.getRouters()) {
+            if (r.isCorner()) {
+                for (TopologyNetwork n : topology.getNetworks()) {
+                    if (n.getInternet()) {
+                        NetworkInterface nI = findCorrectInterface(r, n);
+                        findController(r).executeCommand(r, "/nat " + nI.getName());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Stops device, connects device to target network and again start device.
+     *
+     * @param device             device to be connected
+     * @param network            network where device will be connected
+     * @param calculatedTopology the topology which of network
+     * @param tag                tag of device
+     * @param envVars            environment variables passed to the container
+     */
+    public void deployDeviceToNetwork(Device device, TopologyNetwork network, Topology calculatedTopology, String tag, List<String> envVars) {
+        ArrayList<TopologyNetwork> networks = calculatedTopology.getNetworks();
+        calculatedTopology.addDevice(device);
+        deployToNetwork(device, tag, network, envVars);
+        int internet = 0, sourceNet = 0;
+        for (int i = 0; i < networks.size(); i++) {
+            if (networks.get(i).getInternet()) {
+                internet = i;
+            }
+            if (networks.get(i).getName().equals(network.getName())) {
+                sourceNet = i;
+            }
+        }
+        Router nearRouter = networks.get(sourceNet).getCalcRoutes().get(internet).getNextHop().getRouter();
+        NetworkInterface nI = findCorrectInterface(nearRouter, network);
+
+        RouteRestController routeRestController = new RouteRestController();
+        Route route = new Route();
+        route.setrNetworkInterface(nI);
+        routeRestController.delDefaultGw(device.getIPAddress(), device.getManagementPort());
+        routeRestController.addDefaultGW(route, device.getIPAddress(), device.getManagementPort());
+    }
+
+    /**
+     * Deploys device to network means create device, connect it to target network and start it.
+     *
+     * @param device
+     * @param tag
+     * @param network
+     * @param envVars
+     */
+    private void deployToNetwork(Device device, String tag, TopologyNetwork network, List<String> envVars) {
+        Controller deviceController = findController(device);
+        deviceController.deployDevice(device, tag, monitoringAddr, monitoringPort, envVars);
+        deviceController.connectDeviceToNetwork(device, network);
+        device.getConnectedNetworks().add(network);
+    }
+}

--- a/src/main/java/io/patriot_framework/network_simulator/docker/topology/ContainerTopologyManager.java
+++ b/src/main/java/io/patriot_framework/network_simulator/docker/topology/ContainerTopologyManager.java
@@ -22,7 +22,7 @@ import io.patriot_framework.network.simulator.api.control.Controller;
 import io.patriot_framework.network.simulator.api.model.EnvironmentPart;
 import io.patriot_framework.network.simulator.api.model.devices.Device;
 import io.patriot_framework.network_simulator.docker.api.iproute.RouteRestController;
-import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.ContainerTopology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
@@ -131,7 +131,7 @@ public class ContainerTopologyManager {
      *
      * @param topology
      */
-    public void deployTopology(Topology topology) {
+    public void deployTopology(ContainerTopology topology) {
         createNetworks(topology.getNetworks());
         createRouters(topology);
         connectNetworks(topology);
@@ -156,7 +156,7 @@ public class ContainerTopologyManager {
      *
      * @param topology the representation of topology where shortest paths are to be found
      */
-    public void calcRoutes(Topology topology) {
+    public void calcRoutes(ContainerTopology topology) {
         ArrayList<ContainerNetwork> topologyNetworks = topology.getNetworks();
         LOGGER.info("Calculating network routes.");
         int size = topologyNetworks.size();
@@ -195,7 +195,7 @@ public class ContainerTopologyManager {
      *
      * @param topology topology of network
      */
-    public void processRoutes(Topology topology) {
+    public void processRoutes(ContainerTopology topology) {
         LOGGER.info("Processing routes to ipRoute2 format.");
         ArrayList<ContainerNetwork> calculatedTop = topology.getNetworks();
         int size = calculatedTop.size();
@@ -320,7 +320,7 @@ public class ContainerTopologyManager {
      *
      * @param topology topology of network
      */
-    public void setRoutes(Topology topology) {
+    public void setRoutes(ContainerTopology topology) {
         RouteRestController routeController = new RouteRestController();
         for (Map.Entry<String, ArrayList<Route>> entry : processedRoutes.entrySet()) {
             Router r = topology.findRouterByName(entry.getKey());
@@ -345,7 +345,7 @@ public class ContainerTopologyManager {
      *
      * @param topology topology of network
      */
-    private void updateRouters(Topology topology) {
+    private void updateRouters(ContainerTopology topology) {
         RouteRestController restController = new RouteRestController();
         LOGGER.info("Requesting information about routers interfaces.");
         for (Router r : topology.getRouters()) {
@@ -358,7 +358,7 @@ public class ContainerTopologyManager {
      *
      * @param topology
      */
-    private void connectNetworks(Topology topology) {
+    private void connectNetworks(ContainerTopology topology) {
         LOGGER.info("Initializing corner network address");
         initializeCornerNetworkIP(topology);
         LOGGER.info("Connecting networks.");
@@ -381,7 +381,7 @@ public class ContainerTopologyManager {
      *
      * @param topology topology of network
      */
-    private void initializeCornerNetworkIP(Topology topology) {
+    private void initializeCornerNetworkIP(ContainerTopology topology) {
         for (ContainerNetwork n : topology.getNetworks()) {
             if (n.getInternet()) {
                 Device device = findDeviceWithCreator(topology, n.getCreator());
@@ -400,7 +400,7 @@ public class ContainerTopologyManager {
      * @param creator  creating object
      * @return
      */
-    private Device findDeviceWithCreator(Topology topology, Object creator) {
+    private Device findDeviceWithCreator(ContainerTopology topology, Object creator) {
         for (Device device : topology.getRouters()) {
             if (device.getCreator().equals(creator)) {
                 return device;
@@ -416,7 +416,7 @@ public class ContainerTopologyManager {
      * @param topology
      * @return Hash map with router`s name as key and networks with which router has to be connected
      */
-    private HashMap<String, List<ContainerNetwork>> filterConnected(Topology topology) {
+    private HashMap<String, List<ContainerNetwork>> filterConnected(ContainerTopology topology) {
         LOGGER.info("Filtering direct connections.");
         HashMap<String, List<ContainerNetwork>> connections = new HashMap<>();
 
@@ -479,7 +479,7 @@ public class ContainerTopologyManager {
      *
      * @param topology
      */
-    private void createRouters(Topology topology) {
+    private void createRouters(ContainerTopology topology) {
         for (Router router : topology.getRouters()) {
             LOGGER.debug("Creating router: " + router.getName());
             if (monitoringAddr != null && monitoringPort != 0) {
@@ -517,7 +517,7 @@ public class ContainerTopologyManager {
      *
      * @param topology
      */
-    public void cleanUp(Topology topology) {
+    public void cleanUp(ContainerTopology topology) {
         Controller controller;
         for (Router r : topology.getRouters()) {
             controller = findController(r);
@@ -554,7 +554,7 @@ public class ContainerTopologyManager {
      *
      * @param topology topology of network
      */
-    public void setMasquerade(Topology topology) {
+    public void setMasquerade(ContainerTopology topology) {
         for (Router r : topology.getRouters()) {
             if (r.isCorner()) {
                 for (ContainerNetwork n : topology.getNetworks()) {
@@ -576,7 +576,7 @@ public class ContainerTopologyManager {
      * @param tag                tag of device
      * @param envVars            environment variables passed to the container
      */
-    public void deployDeviceToNetwork(Device device, ContainerNetwork network, Topology calculatedTopology, String tag, List<String> envVars) {
+    public void deployDeviceToNetwork(Device device, ContainerNetwork network, ContainerTopology calculatedTopology, String tag, List<String> envVars) {
         ArrayList<ContainerNetwork> networks = calculatedTopology.getNetworks();
         calculatedTopology.addDevice(device);
         deployToNetwork(device, tag, network, envVars);

--- a/src/test/java/io/patriot_framework/network_simulator/docker/BuilderTests.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/BuilderTests.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker;
+
+import io.patriot_framework.network_simulator.docker.builder.CalcRouteBuilder;
+import io.patriot_framework.network_simulator.docker.builder.NetworkBuilder;
+import io.patriot_framework.network_simulator.docker.builder.RouterBuilder;
+import io.patriot_framework.network_simulator.docker.builder.TopologyBuilder;
+import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class BuilderTests {
+
+    @Test
+    public void calcRouteBuilderTest() {
+        RouterImpl router = new RouterImpl("TestRt", "Docker");
+        int destNetwork = 1;
+        int cost = 10;
+        NextHop nextHop = new NextHop(router, destNetwork);
+        CalcRoute calcRoute = new CalcRoute(nextHop, cost);
+        CalcRouteBuilder calcRouteBuilder = new CalcRouteBuilder(destNetwork);
+        CalcRoute builderRoute = calcRouteBuilder.withCost(10)
+                .viaRouter(router)
+                .createCalcRoute();
+        Assertions.assertEquals(builderRoute, calcRoute);
+
+
+    }
+
+    @Test
+    public void networkBuilderTest() {
+        CalculatedRouteList calcRoutes = new CalculatedRouteList();
+        NextHop nextHop = new NextHop(new RouterImpl("TestRt", "Docker"), 1);
+        CalcRoute calcRoute = new CalcRoute(nextHop, 10);
+        calcRoutes.add(calcRoute);
+
+        TopologyNetwork topologyNetwork = new TopologyNetwork();
+        topologyNetwork.setCreator("Docker");
+        topologyNetwork.setMask(24);
+        topologyNetwork.setIPAddress("192.168.1.0");
+        topologyNetwork.setInternet(true);
+        topologyNetwork.setName("TestNet");
+        topologyNetwork.setCalcRoutes(calcRoutes);
+
+        TopologyNetwork builderNetwork = new NetworkBuilder("TestNet")
+                .withCalcRoutes(calcRoutes)
+                .withCreator("Docker")
+                .withInternet(true)
+                .withIP("192.168.1.0")
+                .withMask(24)
+                .build();
+        Assertions.assertEquals(builderNetwork, topologyNetwork);
+    }
+
+    @Test
+    public void networkBuilderObjectTest() {
+        CalculatedRouteList calcRoutes = new CalculatedRouteList();
+        NextHop nextHop = new NextHop(new RouterImpl("TestRt", 'x'), 1);
+        CalcRoute calcRoute = new CalcRoute(nextHop, 10);
+        calcRoutes.add(calcRoute);
+
+        TopologyNetwork topologyNetwork = new TopologyNetwork();
+        topologyNetwork.setCreator('x');
+        topologyNetwork.setMask(24);
+        topologyNetwork.setIPAddress("192.168.1.0");
+        topologyNetwork.setInternet(true);
+        topologyNetwork.setName("TestNet");
+        topologyNetwork.setCalcRoutes(calcRoutes);
+
+        TopologyNetwork builderNetwork = new NetworkBuilder("TestNet")
+                .withCalcRoutes(calcRoutes)
+                .withCreator('x')
+                .withInternet(true)
+                .withIP("192.168.1.0")
+                .withMask(24)
+                .build();
+        Assertions.assertEquals(builderNetwork, topologyNetwork);
+    }
+
+    @Test
+    public void routerBuilderTest() {
+        RouterImpl rtImpl = new RouterImpl("TestRt", "Docker", true);
+        Router buildedRouter = new RouterBuilder("TestRt")
+                .withCorner(true)
+                .withCreator("Docker")
+                .build();
+        Assertions.assertEquals(buildedRouter, rtImpl);
+
+    }
+
+    @Test
+    public void routerBuilderObjectTest() {
+        RouterImpl rtImpl = new RouterImpl("TestRt", 5, true);
+        Router buildedRouter = new RouterBuilder("TestRt")
+                .withCorner(true)
+                .withCreator(5)
+                .build();
+        Assertions.assertEquals(buildedRouter, rtImpl);
+
+    }
+
+    @Test
+    public void topologyBuilderTest() {
+        RouterImpl rtImpl = new RouterImpl("TestRt", "Docker", true);
+        Topology topology = new Topology(2);
+        topology.setRouters(Arrays.asList(rtImpl));
+        topology.setNetworks(prepareNetwork(rtImpl));
+
+        Topology builderTopology = new TopologyBuilder(2)
+                .withCreator("Docker")
+                .withRouters()
+                .withCorner(true)
+                .withName("TestRt")
+                .createRouter()
+                .addRouters()
+                .withNetwork("TestNet1")
+                .withMask(24)
+                .withIP("192.168.1.0")
+                .withInternet(true)
+                .create()
+                .withNetwork("TestNet2")
+                .withMask(24)
+                .withIP("192.168.2.0")
+                .withInternet(false)
+                .create()
+                .withRoutes()
+                .viaRouter("TestRt")
+                .withDestNetwork(1)
+                .withSourceNetwork(0)
+                .withCost(1)
+                .addRoute()
+                .buildRoutes()
+                .build();
+        Assertions.assertEquals(topology, builderTopology);
+    }
+
+    private ArrayList<TopologyNetwork> prepareNetwork(Router router) {
+        ArrayList<TopologyNetwork> topologyNetworks = new ArrayList<>();
+        NextHop nextHop = new NextHop(router, 1);
+        CalcRoute calcRoute = new CalcRoute(nextHop, 1);
+
+        NextHop nextHop1 = new NextHop(router, 0);
+        CalcRoute calcRoute1 = new CalcRoute(nextHop1, 1);
+
+        CalculatedRouteList calcRoutes = new CalculatedRouteList<>();
+        CalculatedRouteList calcRoutes2 = new CalculatedRouteList();
+        calcRoutes2.add(0, calcRoute1);
+        calcRoutes2.add(1, new CalcRoute(new NextHop(null, 1), null));
+        calcRoutes.add(1, calcRoute);
+        calcRoutes.add(0, new CalcRoute(new NextHop(null, 0), null));
+
+        TopologyNetwork tpN1 = new TopologyNetwork();
+        tpN1.setCreator("Docker");
+        tpN1.setMask(24);
+        tpN1.setIPAddress("192.168.1.0");
+        tpN1.setInternet(true);
+        tpN1.setName("TestNet1");
+        tpN1.setCalcRoutes(calcRoutes);
+        topologyNetworks.add(tpN1);
+
+        TopologyNetwork tpN2 = new TopologyNetwork();
+        tpN2.setCreator("Docker");
+        tpN2.setMask(24);
+        tpN2.setIPAddress("192.168.2.0");
+        tpN2.setInternet(false);
+        tpN2.setName("TestNet2");
+        tpN2.setCalcRoutes(calcRoutes2);
+        topologyNetworks.add(tpN2);
+
+        return topologyNetworks;
+    }
+}

--- a/src/test/java/io/patriot_framework/network_simulator/docker/BuilderTests.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/BuilderTests.java
@@ -20,7 +20,7 @@ import io.patriot_framework.network_simulator.docker.builder.CalcRouteBuilder;
 import io.patriot_framework.network_simulator.docker.builder.NetworkBuilder;
 import io.patriot_framework.network_simulator.docker.builder.RouterBuilder;
 import io.patriot_framework.network_simulator.docker.builder.TopologyBuilder;
-import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.ContainerTopology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
 import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
@@ -125,11 +125,11 @@ public class BuilderTests {
     @Test
     public void topologyBuilderTest() {
         RouterImpl rtImpl = new RouterImpl("TestRt", "Docker", true);
-        Topology topology = new Topology(2);
+        ContainerTopology topology = new ContainerTopology(2);
         topology.setRouters(Arrays.asList(rtImpl));
         topology.setNetworks(prepareNetwork(rtImpl));
 
-        Topology builderTopology = new TopologyBuilder(2)
+        ContainerTopology builderContainerTopology = new TopologyBuilder(2)
                 .withCreator("Docker")
                 .withRouters()
                 .withCorner(true)
@@ -154,7 +154,7 @@ public class BuilderTests {
                 .addRoute()
                 .buildRoutes()
                 .build();
-        Assertions.assertEquals(topology, builderTopology);
+        Assertions.assertEquals(topology, builderContainerTopology);
     }
 
     private ArrayList<ContainerNetwork> prepareNetwork(Router router) {

--- a/src/test/java/io/patriot_framework/network_simulator/docker/BuilderTests.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/BuilderTests.java
@@ -23,7 +23,7 @@ import io.patriot_framework.network_simulator.docker.builder.TopologyBuilder;
 import io.patriot_framework.network_simulator.docker.model.Topology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
 import org.junit.jupiter.api.Assertions;
@@ -57,7 +57,7 @@ public class BuilderTests {
         CalcRoute calcRoute = new CalcRoute(nextHop, 10);
         calcRoutes.add(calcRoute);
 
-        TopologyNetwork topologyNetwork = new TopologyNetwork();
+        ContainerNetwork topologyNetwork = new ContainerNetwork();
         topologyNetwork.setCreator("Docker");
         topologyNetwork.setMask(24);
         topologyNetwork.setIPAddress("192.168.1.0");
@@ -65,7 +65,7 @@ public class BuilderTests {
         topologyNetwork.setName("TestNet");
         topologyNetwork.setCalcRoutes(calcRoutes);
 
-        TopologyNetwork builderNetwork = new NetworkBuilder("TestNet")
+        ContainerNetwork builderNetwork = new NetworkBuilder("TestNet")
                 .withCalcRoutes(calcRoutes)
                 .withCreator("Docker")
                 .withInternet(true)
@@ -82,7 +82,7 @@ public class BuilderTests {
         CalcRoute calcRoute = new CalcRoute(nextHop, 10);
         calcRoutes.add(calcRoute);
 
-        TopologyNetwork topologyNetwork = new TopologyNetwork();
+        ContainerNetwork topologyNetwork = new ContainerNetwork();
         topologyNetwork.setCreator('x');
         topologyNetwork.setMask(24);
         topologyNetwork.setIPAddress("192.168.1.0");
@@ -90,7 +90,7 @@ public class BuilderTests {
         topologyNetwork.setName("TestNet");
         topologyNetwork.setCalcRoutes(calcRoutes);
 
-        TopologyNetwork builderNetwork = new NetworkBuilder("TestNet")
+        ContainerNetwork builderNetwork = new NetworkBuilder("TestNet")
                 .withCalcRoutes(calcRoutes)
                 .withCreator('x')
                 .withInternet(true)
@@ -157,8 +157,8 @@ public class BuilderTests {
         Assertions.assertEquals(topology, builderTopology);
     }
 
-    private ArrayList<TopologyNetwork> prepareNetwork(Router router) {
-        ArrayList<TopologyNetwork> topologyNetworks = new ArrayList<>();
+    private ArrayList<ContainerNetwork> prepareNetwork(Router router) {
+        ArrayList<ContainerNetwork> topologyNetworks = new ArrayList<>();
         NextHop nextHop = new NextHop(router, 1);
         CalcRoute calcRoute = new CalcRoute(nextHop, 1);
 
@@ -172,7 +172,7 @@ public class BuilderTests {
         calcRoutes.add(1, calcRoute);
         calcRoutes.add(0, new CalcRoute(new NextHop(null, 0), null));
 
-        TopologyNetwork tpN1 = new TopologyNetwork();
+        ContainerNetwork tpN1 = new ContainerNetwork();
         tpN1.setCreator("Docker");
         tpN1.setMask(24);
         tpN1.setIPAddress("192.168.1.0");
@@ -181,7 +181,7 @@ public class BuilderTests {
         tpN1.setCalcRoutes(calcRoutes);
         topologyNetworks.add(tpN1);
 
-        TopologyNetwork tpN2 = new TopologyNetwork();
+        ContainerNetwork tpN2 = new ContainerNetwork();
         tpN2.setCreator("Docker");
         tpN2.setMask(24);
         tpN2.setIPAddress("192.168.2.0");

--- a/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
@@ -21,7 +21,7 @@ import io.patriot_framework.network_simulator.docker.manager.Manager;
 import io.patriot_framework.network_simulator.docker.model.Topology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
 import org.junit.jupiter.api.Assertions;
@@ -32,10 +32,10 @@ import java.util.Arrays;
 
 public class FloydWarshallTest {
 
-    private ArrayList<TopologyNetwork> copyTopology(ArrayList<TopologyNetwork> topology) {
-        ArrayList<TopologyNetwork> resultTop = new ArrayList<>();
+    private ArrayList<ContainerNetwork> copyTopology(ArrayList<ContainerNetwork> topology) {
+        ArrayList<ContainerNetwork> resultTop = new ArrayList<>();
         for (int i = 0; i < topology.size(); i++) {
-            TopologyNetwork n = new TopologyNetwork();
+            ContainerNetwork n = new ContainerNetwork();
             n.setInternet(topology.get(i).getInternet());
             n.setName(topology.get(i).getName());
             n.setMask(topology.get(i).getMask());
@@ -45,8 +45,8 @@ public class FloydWarshallTest {
         return resultTop;
     }
 
-    private ArrayList<TopologyNetwork> prepareResultTopology(ArrayList<TopologyNetwork> topology) {
-        ArrayList<TopologyNetwork> resultTop = copyTopology(topology);
+    private ArrayList<ContainerNetwork> prepareResultTopology(ArrayList<ContainerNetwork> topology) {
+        ArrayList<ContainerNetwork> resultTop = copyTopology(topology);
         CalculatedRouteList n1Routes = new CalculatedRouteList();
         n1Routes.add(new CalcRoute(new NextHop(null, 0), null));
         n1Routes.add(new CalcRoute(new NextHop(null, 1), 1));
@@ -93,7 +93,7 @@ public class FloydWarshallTest {
     @Test
     public void FloydWarshallTest() {
 
-        ArrayList<TopologyNetwork> topologyNetworks = new ArrayList<>(4);
+        ArrayList<ContainerNetwork> containerNetworks = new ArrayList<>(4);
         ArrayList<Router> routers = new ArrayList<>();
 
 
@@ -102,41 +102,41 @@ public class FloydWarshallTest {
         routers.add(new RouterImpl("R3"));
         routers.add(new RouterImpl("R5"));
 
-        TopologyNetwork n1 = new TopologyNetwork();
+        ContainerNetwork n1 = new ContainerNetwork();
         n1.setIPAddress("192.168.0.0");
         n1.setName("TN1");
         n1.setMask(28);
 
-        TopologyNetwork n2 = new TopologyNetwork();
+        ContainerNetwork n2 = new ContainerNetwork();
         n2.setMask(28);
         n2.setIPAddress("192.168.16.0");
         n2.setName("TN2");
 
-        TopologyNetwork n3 = new TopologyNetwork();
+        ContainerNetwork n3 = new ContainerNetwork();
         n3.setName("TN3");
         n3.setMask(28);
         n3.setIPAddress("192.168.32.0");
 
-        TopologyNetwork n4 = new TopologyNetwork();
+        ContainerNetwork n4 = new ContainerNetwork();
         n4.setMask(28);
         n4.setIPAddress("192.168.48.0");
         n4.setName("TN4");
 
-        TopologyNetwork internet = new TopologyNetwork();
+        ContainerNetwork internet = new ContainerNetwork();
         internet.setInternet(true);
 
-        topologyNetworks.addAll(Arrays.asList(n1, n2, n3, n4, internet));
-        Topology topology = new Topology(routers, topologyNetworks);
+        containerNetworks.addAll(Arrays.asList(n1, n2, n3, n4, internet));
+        Topology topology = new Topology(routers, containerNetworks);
 
-        initNetworks(topologyNetworks, routers);
+        initNetworks(containerNetworks, routers);
         // TODO: remove docker-network-simulator specific methods from Manager
         Manager networkManager = new Manager("patriotRouter");
-        ArrayList<TopologyNetwork> resArr = prepareResultTopology(topologyNetworks);
+        ArrayList<ContainerNetwork> resArr = prepareResultTopology(containerNetworks);
         networkManager.calcRoutes(topology);
 
         for (int i = 0; i < 5; i++) {
-            TopologyNetwork targetTopologyNetwork = topologyNetworks.get(i);
-            TopologyNetwork resultTopologyNetwork = resArr.get(i);
+            ContainerNetwork targetTopologyNetwork = containerNetworks.get(i);
+            ContainerNetwork resultTopologyNetwork = resArr.get(i);
             for (int y = 0; y < 5; y++) {
                 Assertions.assertEquals(targetTopologyNetwork.getCalcRoutes().get(y).getCost(),
                         resultTopologyNetwork.getCalcRoutes().get(y).getCost());
@@ -149,14 +149,14 @@ public class FloydWarshallTest {
     }
 
 
-    private void initNetworks(ArrayList<TopologyNetwork> topology, ArrayList<Router> routers) {
+    private void initNetworks(ArrayList<ContainerNetwork> topology, ArrayList<Router> routers) {
 
         Integer routNeedCalc = topology.size() + 1;
-        TopologyNetwork tN1 = topology.get(0);
-        TopologyNetwork tN2 = topology.get(1);
-        TopologyNetwork tN3 = topology.get(2);
-        TopologyNetwork tN4 = topology.get(3);
-        TopologyNetwork internet = topology.get(4);
+        ContainerNetwork tN1 = topology.get(0);
+        ContainerNetwork tN2 = topology.get(1);
+        ContainerNetwork tN3 = topology.get(2);
+        ContainerNetwork tN4 = topology.get(3);
+        ContainerNetwork internet = topology.get(4);
 
         tN1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), null));
         tN1.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(0), 1), 1));

--- a/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
@@ -24,6 +24,7 @@ import io.patriot_framework.network_simulator.docker.model.devices.router.Router
 import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
+import io.patriot_framework.network_simulator.docker.topology.ContainerTopologyManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -129,8 +130,7 @@ public class FloydWarshallTest {
         Topology topology = new Topology(routers, containerNetworks);
 
         initNetworks(containerNetworks, routers);
-        // TODO: remove docker-network-simulator specific methods from Manager
-        Manager networkManager = new Manager("patriotRouter");
+        ContainerTopologyManager networkManager = new ContainerTopologyManager("patriotRouter");
         ArrayList<ContainerNetwork> resArr = prepareResultTopology(containerNetworks);
         networkManager.calcRoutes(topology);
 

--- a/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker;
+
+
+import io.patriot_framework.network_simulator.docker.manager.Manager;
+import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class FloydWarshallTest {
+
+    private ArrayList<TopologyNetwork> copyTopology(ArrayList<TopologyNetwork> topology) {
+        ArrayList<TopologyNetwork> resultTop = new ArrayList<>();
+        for (int i = 0; i < topology.size(); i++) {
+            TopologyNetwork n = new TopologyNetwork();
+            n.setInternet(topology.get(i).getInternet());
+            n.setName(topology.get(i).getName());
+            n.setMask(topology.get(i).getMask());
+            n.setIPAddress(topology.get(i).getIPAddress());
+            resultTop.add(n);
+        }
+        return resultTop;
+    }
+
+    private ArrayList<TopologyNetwork> prepareResultTopology(ArrayList<TopologyNetwork> topology) {
+        ArrayList<TopologyNetwork> resultTop = copyTopology(topology);
+        CalculatedRouteList n1Routes = new CalculatedRouteList();
+        n1Routes.add(new CalcRoute(new NextHop(null, 0), null));
+        n1Routes.add(new CalcRoute(new NextHop(null, 1), 1));
+        n1Routes.add(new CalcRoute(new NextHop(null, 1), 2));
+        n1Routes.add(new CalcRoute(new NextHop(null, 1), 2));
+        n1Routes.add(new CalcRoute(new NextHop(null, 1), 3));
+        resultTop.get(0).setCalcRoutes(n1Routes);
+
+        CalculatedRouteList n2Routes = new CalculatedRouteList();
+        n2Routes.add(new CalcRoute(new NextHop(null, 0), 1));
+        n2Routes.add(new CalcRoute(new NextHop(null, 1), null));
+        n2Routes.add(new CalcRoute(new NextHop(null, 2), 1));
+        n2Routes.add(new CalcRoute(new NextHop(null, 3), 1));
+        n2Routes.add(new CalcRoute(new NextHop(null, 2), 2));
+        resultTop.get(1).setCalcRoutes(n2Routes);
+
+        CalculatedRouteList n3Routes = new CalculatedRouteList();
+        n3Routes.add(new CalcRoute(new NextHop(null, 1), 2));
+        n3Routes.add(new CalcRoute(new NextHop(null, 1), 1));
+        n3Routes.add(new CalcRoute(new NextHop(null, 2), null));
+        n3Routes.add(new CalcRoute(new NextHop(null, 3), 1));
+        n3Routes.add(new CalcRoute(new NextHop(null, 4), 1));
+        resultTop.get(2).setCalcRoutes(n3Routes);
+
+        CalculatedRouteList n4Routes = new CalculatedRouteList();
+        n4Routes.add(new CalcRoute(new NextHop(null, 1), 2));
+        n4Routes.add(new CalcRoute(new NextHop(null, 1), 1));
+        n4Routes.add(new CalcRoute(new NextHop(null, 2), 1));
+        n4Routes.add(new CalcRoute(new NextHop(null, 3), null));
+        n4Routes.add(new CalcRoute(new NextHop(null, 4), 1));
+        resultTop.get(3).setCalcRoutes(n4Routes);
+
+        CalculatedRouteList n5Routes = new CalculatedRouteList();
+        n5Routes.add(new CalcRoute(new NextHop(null, 2), 3));
+        n5Routes.add(new CalcRoute(new NextHop(null, 2), 2));
+        n5Routes.add(new CalcRoute(new NextHop(null, 2), 1));
+        n5Routes.add(new CalcRoute(new NextHop(null, 3), 1));
+        n5Routes.add(new CalcRoute(new NextHop(null, 4), null));
+        resultTop.get(4).setCalcRoutes(n5Routes);
+
+        return resultTop;
+    }
+
+    @Test
+    public void FloydWarshallTest() {
+
+        ArrayList<TopologyNetwork> topologyNetworks = new ArrayList<>(4);
+        ArrayList<Router> routers = new ArrayList<>();
+
+
+        routers.add(new RouterImpl("R1"));
+        routers.add(new RouterImpl("R2"));
+        routers.add(new RouterImpl("R3"));
+        routers.add(new RouterImpl("R5"));
+
+        TopologyNetwork n1 = new TopologyNetwork();
+        n1.setIPAddress("192.168.0.0");
+        n1.setName("TN1");
+        n1.setMask(28);
+
+        TopologyNetwork n2 = new TopologyNetwork();
+        n2.setMask(28);
+        n2.setIPAddress("192.168.16.0");
+        n2.setName("TN2");
+
+        TopologyNetwork n3 = new TopologyNetwork();
+        n3.setName("TN3");
+        n3.setMask(28);
+        n3.setIPAddress("192.168.32.0");
+
+        TopologyNetwork n4 = new TopologyNetwork();
+        n4.setMask(28);
+        n4.setIPAddress("192.168.48.0");
+        n4.setName("TN4");
+
+        TopologyNetwork internet = new TopologyNetwork();
+        internet.setInternet(true);
+
+        topologyNetworks.addAll(Arrays.asList(n1, n2, n3, n4, internet));
+        Topology topology = new Topology(routers, topologyNetworks);
+
+        initNetworks(topologyNetworks, routers);
+        // TODO: remove docker-network-simulator specific methods from Manager
+        Manager networkManager = new Manager("patriotRouter");
+        ArrayList<TopologyNetwork> resArr = prepareResultTopology(topologyNetworks);
+        networkManager.calcRoutes(topology);
+
+        for (int i = 0; i < 5; i++) {
+            TopologyNetwork targetTopologyNetwork = topologyNetworks.get(i);
+            TopologyNetwork resultTopologyNetwork = resArr.get(i);
+            for (int y = 0; y < 5; y++) {
+                Assertions.assertEquals(targetTopologyNetwork.getCalcRoutes().get(y).getCost(),
+                        resultTopologyNetwork.getCalcRoutes().get(y).getCost());
+
+                Assertions.assertEquals(targetTopologyNetwork.getCalcRoutes().get(y).getNextHop().getNetwork(),
+                        resultTopologyNetwork.getCalcRoutes().get(y).getNextHop().getNetwork());
+            }
+        }
+
+    }
+
+
+    private void initNetworks(ArrayList<TopologyNetwork> topology, ArrayList<Router> routers) {
+
+        Integer routNeedCalc = topology.size() + 1;
+        TopologyNetwork tN1 = topology.get(0);
+        TopologyNetwork tN2 = topology.get(1);
+        TopologyNetwork tN3 = topology.get(2);
+        TopologyNetwork tN4 = topology.get(3);
+        TopologyNetwork internet = topology.get(4);
+
+        tN1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), null));
+        tN1.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(0), 1), 1));
+        tN1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 2), routNeedCalc));
+        tN1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 3), routNeedCalc));
+        tN1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 4), routNeedCalc));
+
+        tN2.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(0), 0), 1));
+        tN2.getCalcRoutes().add(new CalcRoute(new NextHop(null, 1), null));
+        tN2.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(1), 2), 1));
+        tN2.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(2), 3), 1));
+        tN2.getCalcRoutes().add(new CalcRoute(new NextHop(null, 4), routNeedCalc));
+
+        tN3.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), routNeedCalc));
+        tN3.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(1), 1), 1));
+        tN3.getCalcRoutes().add(new CalcRoute(new NextHop(null, 2), null));
+        tN3.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(3), 3), 1));
+        tN3.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(3), 4), 1));
+
+        tN4.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), routNeedCalc));
+        tN4.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(2), 1), 1));
+        tN4.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(3), 2), 1));
+        tN4.getCalcRoutes().add(new CalcRoute(new NextHop(null, 3), null));
+        tN4.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(3), 4), 1));
+
+        internet.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), routNeedCalc));
+        internet.getCalcRoutes().add(new CalcRoute(new NextHop(null, 1), routNeedCalc));
+        internet.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(3), 2), 1));
+        internet.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(3), 3), 1));
+        internet.getCalcRoutes().add(new CalcRoute(new NextHop(null, 4), null));
+    }
+}

--- a/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/FloydWarshallTest.java
@@ -17,8 +17,7 @@
 package io.patriot_framework.network_simulator.docker;
 
 
-import io.patriot_framework.network_simulator.docker.manager.Manager;
-import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.ContainerTopology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
 import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
@@ -127,7 +126,7 @@ public class FloydWarshallTest {
         internet.setInternet(true);
 
         containerNetworks.addAll(Arrays.asList(n1, n2, n3, n4, internet));
-        Topology topology = new Topology(routers, containerNetworks);
+        ContainerTopology topology = new ContainerTopology(routers, containerNetworks);
 
         initNetworks(containerNetworks, routers);
         ContainerTopologyManager networkManager = new ContainerTopologyManager("patriotRouter");

--- a/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
@@ -16,8 +16,7 @@
 
 package io.patriot_framework.network_simulator.docker;
 
-import io.patriot_framework.network.simulator.api.manager.Manager;
-import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.ContainerTopology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
@@ -41,7 +40,7 @@ public class RouteTreatmentTest {
     @Test
     public void testRouteTreatmentTest() {
         ArrayList<ContainerNetwork> topologyNetworks = new ArrayList<>();
-        Topology topology = new Topology(topologyNetworks);
+        ContainerTopology topology = new ContainerTopology(topologyNetworks);
         Router r = new RouterImpl("TestRouter", "Docker");
         Route route = createSimpleTopology(topologyNetworks, false, r);
         manager.processRoutes(topology);

--- a/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
@@ -21,7 +21,7 @@ import io.patriot_framework.network_simulator.docker.model.Topology;
 import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
 import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
 import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
-import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.network.ContainerNetwork;
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
 import io.patriot_framework.network_simulator.docker.model.routes.Route;
@@ -39,7 +39,7 @@ public class RouteTreatmentTest {
 
     @Test
     public void testRouteTreatmentTest() {
-        ArrayList<TopologyNetwork> topologyNetworks = new ArrayList<>();
+        ArrayList<ContainerNetwork> topologyNetworks = new ArrayList<>();
         Topology topology = new Topology(topologyNetworks);
         Router r = new RouterImpl("TestRouter", "Docker");
         Route route = createSimpleTopology(topologyNetworks, false, r);
@@ -48,7 +48,7 @@ public class RouteTreatmentTest {
 
     }
 
-    private Route parseRoute(TopologyNetwork source, TopologyNetwork dest, Router targetRouter, NetworkInterface targetInterface) {
+    private Route parseRoute(ContainerNetwork source, ContainerNetwork dest, Router targetRouter, NetworkInterface targetInterface) {
         Route route = new Route();
         route.setrNetworkInterface(targetInterface);
         route.setSource(source);
@@ -57,18 +57,18 @@ public class RouteTreatmentTest {
         return route;
     }
 
-    private Route createSimpleTopology(ArrayList<TopologyNetwork> topology, Boolean duplicate, Router r) {
+    private Route createSimpleTopology(ArrayList<ContainerNetwork> topology, Boolean duplicate, Router r) {
         List<NetworkInterface> routerInterfaces = new ArrayList<>();
         routerInterfaces.add(new NetworkInterface("eth0", "192.168.0.2", 24));
         r.setNetworkInterfaces(routerInterfaces);
 
-        TopologyNetwork n1 = new TopologyNetwork();
+        ContainerNetwork n1 = new ContainerNetwork();
         n1.setName("TestNetwork1");
         n1.setIPAddress("172.16.0.0");
         n1.setCreator("Docker");
         n1.setMask(16);
 
-        TopologyNetwork n2 = new TopologyNetwork();
+        ContainerNetwork n2 = new ContainerNetwork();
         n2.setName("TestNetwork2");
         n2.setIPAddress("192.168.0.0");
         n2.setCreator("Docker");
@@ -89,22 +89,22 @@ public class RouteTreatmentTest {
         return calculatedRouteList;
     }
 
-    private ArrayList<TopologyNetwork> prepareComplicatedTopology(ArrayList<Router> routers) {
-        ArrayList<TopologyNetwork> topology = new ArrayList<>();
+    private ArrayList<ContainerNetwork> prepareComplicatedTopology(ArrayList<Router> routers) {
+        ArrayList<ContainerNetwork> topology = new ArrayList<>();
 
-        TopologyNetwork n1 = new TopologyNetwork();
+        ContainerNetwork n1 = new ContainerNetwork();
         n1.setName("TestNetwork1");
         n1.setIPAddress("192.168.1.0");
         n1.setCreator("Docker");
         n1.setMask(28);
 
-        TopologyNetwork n2 = new TopologyNetwork();
+        ContainerNetwork n2 = new ContainerNetwork();
         n2.setName("TestNetwork2");
         n2.setIPAddress("192.168.1.16");
         n2.setCreator("Docker");
         n2.setMask(28);
 
-        TopologyNetwork n3 = new TopologyNetwork();
+        ContainerNetwork n3 = new ContainerNetwork();
         n3.setName("TestNetwork3");
         n3.setIPAddress("192.168.1.32");
         n3.setCreator("Docker");
@@ -115,11 +115,11 @@ public class RouteTreatmentTest {
         return topology;
     }
 
-    private void prepareOnStartTopology(ArrayList<TopologyNetwork> topology, ArrayList<Router> routers) {
+    private void prepareOnStartTopology(ArrayList<ContainerNetwork> topology, ArrayList<Router> routers) {
         Integer routNeedCalc = topology.size() + 1;
-        TopologyNetwork n1 = topology.get(0);
-        TopologyNetwork n2 = topology.get(1);
-        TopologyNetwork n3 = topology.get(2);
+        ContainerNetwork n1 = topology.get(0);
+        ContainerNetwork n2 = topology.get(1);
+        ContainerNetwork n3 = topology.get(2);
 
         n1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), null));
         n1.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(0), 1), 1));

--- a/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 Patriot project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.patriot_framework.network_simulator.docker;
+
+import io.patriot_framework.network.simulator.api.manager.Manager;
+import io.patriot_framework.network_simulator.docker.model.Topology;
+import io.patriot_framework.network_simulator.docker.model.devices.router.NetworkInterface;
+import io.patriot_framework.network_simulator.docker.model.devices.router.Router;
+import io.patriot_framework.network_simulator.docker.model.devices.router.RouterImpl;
+import io.patriot_framework.network_simulator.docker.model.network.TopologyNetwork;
+import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
+import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
+import io.patriot_framework.network_simulator.docker.model.routes.Route;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RouteTreatmentTest {
+
+    private Manager manager = new Manager("patriot");
+
+    @Test
+    public void testRouteTreatmentTest() {
+        ArrayList<TopologyNetwork> topologyNetworks = new ArrayList<>();
+        Topology topology = new Topology(topologyNetworks);
+        Router r = new RouterImpl("TestRouter", "Docker");
+        Route route = createSimpleTopology(topologyNetworks, false, r);
+        manager.processRoutes(topology);
+        assertTrue(manager.getProcessedRoutes().get(r.getName()).get(0).toAPIFormat().equals(route.toAPIFormat()));
+
+    }
+
+    private Route parseRoute(TopologyNetwork source, TopologyNetwork dest, Router targetRouter, NetworkInterface targetInterface) {
+        Route route = new Route();
+        route.setrNetworkInterface(targetInterface);
+        route.setSource(source);
+        route.setDest(dest);
+        route.setTargetRouter(targetRouter);
+        return route;
+    }
+
+    private Route createSimpleTopology(ArrayList<TopologyNetwork> topology, Boolean duplicate, Router r) {
+        List<NetworkInterface> routerInterfaces = new ArrayList<>();
+        routerInterfaces.add(new NetworkInterface("eth0", "192.168.0.2", 24));
+        r.setNetworkInterfaces(routerInterfaces);
+
+        TopologyNetwork n1 = new TopologyNetwork();
+        n1.setName("TestNetwork1");
+        n1.setIPAddress("172.16.0.0");
+        n1.setCreator("Docker");
+        n1.setMask(16);
+
+        TopologyNetwork n2 = new TopologyNetwork();
+        n2.setName("TestNetwork2");
+        n2.setIPAddress("192.168.0.0");
+        n2.setCreator("Docker");
+        n2.setMask(24);
+
+        n1.setCalcRoutes(createCalculatedRouteList(r, 0, 1));
+
+        topology.add(n1);
+        topology.add(n2);
+        return parseRoute(n1, n2, r, routerInterfaces.get(0));
+    }
+
+    private CalculatedRouteList createCalculatedRouteList(Router r, Integer sourceNetwork, Integer destNetwork) {
+        CalcRoute calcRoute = new CalcRoute(new NextHop(r, destNetwork), 1);
+        CalculatedRouteList calculatedRouteList = new CalculatedRouteList();
+        calculatedRouteList.add(destNetwork, calcRoute);
+        calculatedRouteList.add(sourceNetwork, new CalcRoute(new NextHop(null, sourceNetwork), null));
+        return calculatedRouteList;
+    }
+
+    private ArrayList<TopologyNetwork> prepareComplicatedTopology(ArrayList<Router> routers) {
+        ArrayList<TopologyNetwork> topology = new ArrayList<>();
+
+        TopologyNetwork n1 = new TopologyNetwork();
+        n1.setName("TestNetwork1");
+        n1.setIPAddress("192.168.1.0");
+        n1.setCreator("Docker");
+        n1.setMask(28);
+
+        TopologyNetwork n2 = new TopologyNetwork();
+        n2.setName("TestNetwork2");
+        n2.setIPAddress("192.168.1.16");
+        n2.setCreator("Docker");
+        n2.setMask(28);
+
+        TopologyNetwork n3 = new TopologyNetwork();
+        n3.setName("TestNetwork3");
+        n3.setIPAddress("192.168.1.32");
+        n3.setCreator("Docker");
+        n3.setMask(28);
+        topology.addAll(Arrays.asList(n1, n2, n3));
+
+        prepareOnStartTopology(topology, routers);
+        return topology;
+    }
+
+    private void prepareOnStartTopology(ArrayList<TopologyNetwork> topology, ArrayList<Router> routers) {
+        Integer routNeedCalc = topology.size() + 1;
+        TopologyNetwork n1 = topology.get(0);
+        TopologyNetwork n2 = topology.get(1);
+        TopologyNetwork n3 = topology.get(2);
+
+        n1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), null));
+        n1.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(0), 1), 1));
+        n1.getCalcRoutes().add(new CalcRoute(new NextHop(null, 2), routNeedCalc));
+
+
+        n2.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(0), 0), 1));
+        n2.getCalcRoutes().add(new CalcRoute(new NextHop(null, 1), null));
+        n2.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(1), 2), 1));
+
+
+        n3.getCalcRoutes().add(new CalcRoute(new NextHop(null, 0), routNeedCalc));
+        n3.getCalcRoutes().add(new CalcRoute(new NextHop(routers.get(1), 1), 1));
+        n3.getCalcRoutes().add(new CalcRoute(new NextHop(null, 2), null));
+
+    }
+
+}

--- a/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
+++ b/src/test/java/io/patriot_framework/network_simulator/docker/RouteTreatmentTest.java
@@ -25,6 +25,7 @@ import io.patriot_framework.network_simulator.docker.model.network.ContainerNetw
 import io.patriot_framework.network_simulator.docker.model.routes.CalcRoute;
 import io.patriot_framework.network_simulator.docker.model.routes.NextHop;
 import io.patriot_framework.network_simulator.docker.model.routes.Route;
+import io.patriot_framework.network_simulator.docker.topology.ContainerTopologyManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RouteTreatmentTest {
 
-    private Manager manager = new Manager("patriot");
+    private final ContainerTopologyManager manager = new ContainerTopologyManager("patriot");
 
     @Test
     public void testRouteTreatmentTest() {


### PR DESCRIPTION
This PR will move code from patriot-api that is closely related only to the docker simulation of the network.

PR in patriot-api: https://github.com/PatrIoT-Framework/patriot-api/pull/9

- [ ] Refactor builders
- [ ] ContainerTopology implements Topology
- [ ] Proper refactoring of ContainerTopologyManager